### PR TITLE
First version of diff command for roles and users

### DIFF
--- a/src/main/java/pw/chew/chewbotcca/commands/DiffCommand.java
+++ b/src/main/java/pw/chew/chewbotcca/commands/DiffCommand.java
@@ -18,11 +18,14 @@ package pw.chew.chewbotcca.commands;
 
 import com.jagrosh.jdautilities.command.Command;
 import com.jagrosh.jdautilities.command.CommandEvent;
+import io.sentry.Sentry;
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.Permission;
+import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.api.entities.Role;
 
-import java.util.ArrayList;
+import java.awt.*;
+import java.util.*;
 import java.util.List;
 
 public class DiffCommand extends Command {
@@ -32,14 +35,14 @@ public class DiffCommand extends Command {
         this.guildOnly = true;
         this.cooldown = 5;
         this.cooldownScope = CooldownScope.USER;
-        this.children = new Command[]{new CompareRolesSubCommand()};
+        this.children = new Command[]{new CompareRolesSubCommand(), new CompareMembersSubCommand()};
     }
 
     @Override
     protected void execute(CommandEvent event) {
         String[] args = event.getArgs().split(" ");
         if (args.length != 3) {
-            event.reply("Invalid amount of arguments specified. Example: " + event.getPrefix() + "diff ROLE 708085624514543728 134445052805120001");
+            event.reply("Invalid amount of arguments specified. Example: " + event.getPrefix() + "diff role moderator admin");
             return;
         }
 
@@ -47,7 +50,8 @@ public class DiffCommand extends Command {
     }
 
     /**
-     * Compares roles
+     * Compares roles.
+     * Takes 2 String arguments that have to be roles.  Example:  diff role moderator admin
      */
     private static class CompareRolesSubCommand extends Command {
 
@@ -62,44 +66,68 @@ public class DiffCommand extends Command {
             String[] args = event.getArgs().split(" ");
 
             if (args.length != 2) {
-                event.reply("Invalid number of arguments provided. Please provide valid role IDs for this server.");
+                event.reply("Invalid number of arguments provided. Please provide valid role names.");
                 return;
             }
 
-            Role base = event.getGuild().getRoleById(args[0]);
+            String baseString = args[0].toLowerCase();
+            String compareString = args[1].toLowerCase();
+            Role base = null;
+            Role compare = null;
+
+            // iterate through roles to check if base and compare are actual roles.
+            for (Role role : event.getGuild().getRoles()){
+                if(role.getName().toLowerCase().equals(baseString)){
+                    base = role;
+                }
+                if(role.getName().toLowerCase().equals(compareString)){
+                    compare = role;
+                }
+            }
             if (base == null) {
-                event.reply("Unable to find base (first) role. Please ensure you are providing a valid ID to compare.");
+                event.reply("Unable to find base (first) role. Please ensure you are providing a valid role name.");
                 return;
             }
-            Role compare = event.getGuild().getRoleById(args[1]);
             if (compare == null) {
-                event.reply("Unable to find compare (second) role. Please ensure you are providing a valid ID to compare.");
+                event.reply("Unable to find compare (second) role. Please ensure you are providing a valid role to compare.");
                 return;
             }
 
-            EmbedBuilder embed = new EmbedBuilder();
-            embed.setTitle("Comparing roles");
-            embed.setDescription("Comparing name, color, permissions, and other information.\n" +
-                "Base role: " + args[0] + "\n" + "Compare role: " + args[1]);
 
+            EmbedBuilder embed = new EmbedBuilder()
+                    .setTitle("Comparing roles")
+                    .setDescription("Comparing name, color, permissions, and other information.\n" +
+                        "Base role: " + base.getName()  + "\n" + "Compare role: " + compare.getName())
+                    .setColor(new Color(96, 70, 184));
+            try {
+                embed.setThumbnail("https://c1.wallpaperflare.com/preview/634/485/143/analysis-antique-background-balance.jpg");
+            }catch (Exception e){
+                Sentry.captureException(e);
+            }
+
+            // compare names
             if (base.getName().equals(compare.getName())) {
-                embed.addField("Name", "*Nothing to compare. Names are identical*", true);
+                embed.addField("Try again with different roles", "*Nothing to compare. Roles are identical*", true);
+                event.reply(embed.build());
+                return;
             } else {
-                String name = args[0] + ": " + base.getName() + "\n" +
-                    args[1] + ": " + compare.getName();
-                embed.addField("Name", name, true);
+                String name = base.getName() + "\n" +
+                        compare.getName();
+                embed.addField("Name ", name, true);
             }
 
-            if (base.getColor() == compare.getColor()) {
-                embed.addField("Color", "*Nothing to compare. Colors are identical*", true);
+            // compare colors ( RGB values )
+            if (base.getColorRaw() == compare.getColorRaw()) {
+                embed.addField("Color 🔴🟠🟡🟢🔵🟣🟤⚫⚪", "*Nothing to compare. Colors are identical*", true);
             } else {
-                String color = args[0] + ": " + base.getColor() + "\n" +
-                    args[1] + ": " + compare.getColor();
-                embed.addField("Color", color, true);
+                String color = base.getColor()+ "\n" +
+                    compare.getColor();
+                embed.addField("Color 🔴🟠🟡🟢🔵🟣🟤⚫⚪", color, true);
             }
 
+            // compare permissions
             if (base.getPermissionsRaw() == compare.getPermissionsRaw()) {
-                embed.addField("Permissions", "*Nothing to compare. Permissions are identical*", false);
+                embed.addField("✅ Permissions 🚫", "*Nothing to compare. Permissions are identical*", false);
             } else {
                 List<Permission> baseOnly = new ArrayList<>();
                 List<Permission> compareOnly = new ArrayList<>();
@@ -116,12 +144,13 @@ public class DiffCommand extends Command {
                     }
                 }
 
+
                 List<String> perms = new ArrayList<>();
-                perms.add("""
+                String start = """
                     + means compare role has the permission, and base doesn't.
                     - means compare role doesn't have the perm, but base does.
-                    ```diff""");
-
+                     ```diff""".replaceAll("compare",compare.getName()).replaceAll("base",base.getName());
+                perms.add(start);
                 for (Permission perm : compareOnly) {
                     perms.add("+ " + perm.getName());
                 }
@@ -131,11 +160,135 @@ public class DiffCommand extends Command {
                 }
 
                 perms.add("```");
+                embed.addField("✅ Permissions 🚫", String.join("\n", perms), false);
 
-                embed.addField("Permissions", String.join("\n", perms), false);
             }
 
             event.reply(embed.build());
         }
+    }
+
+    /**
+     * Compares users
+     * Takes 2 arguments of type userIdTag. Example: diff member Query#1234 random#4567
+     */
+    private static class CompareMembersSubCommand extends Command{
+
+        public CompareMembersSubCommand() {
+            this.name = "member";
+            this.guildOnly = true;
+            this.botPermissions = new Permission[]{Permission.MESSAGE_EMBED_LINKS};
+        }
+
+        @Override
+        protected void execute(CommandEvent event) {
+            String[] args = event.getArgs().split(" ");
+
+            if (args.length != 2) {
+                event.reply("Invalid number of arguments provided. Please provide valid member names.");
+                return;
+            }
+
+            Member member1 = null;
+            Member member2 = null;
+
+            try {
+                member1 = event.getGuild().getMemberByTag(args[0]);
+                member2 = event.getGuild().getMemberByTag(args[1]);
+            }catch (Exception e){
+                Sentry.captureException(e);
+            }
+
+            if (member1 == null){
+                event.reply("Unable to find first member. Please ensure you are providing a valid tag .");
+                return;
+            }
+            if (member2 == null){
+                event.reply("Unable to find second member. Please ensure you are providing a valid tag .");
+                return;
+            }
+
+
+            EmbedBuilder embed = new EmbedBuilder()
+                    .setTitle("Comparing members")
+                    .setDescription("Comparing Time joined,Time boosted , Roles, and other information.\n" +
+                        "First member: " + member1.getUser().getName() + "\n" + "Second member : " + member2.getUser().getName())
+                    .setColor(new Color(117, 46, 134));
+
+                try {
+                    embed.setThumbnail("https://c1.wallpaperflare.com/preview/634/485/143/analysis-antique-background-balance.jpg");
+                }catch (Exception e){
+                    Sentry.captureException(e);
+                }
+
+
+                if (member1.getUser().getAsTag().equals(member2.getUser().getAsTag())) {
+                    embed.addField("Try again with different members", "*Nothing to compare. Members are identical*", true);
+                    event.reply(embed.build());
+                    return;
+                } else {
+                    String names = member1.getUser().getName() + "\n" +
+                            member2.getUser().getName();
+                    embed.addField("Name", names, true);
+                }
+
+                // Dates of arrival in server
+                String date = member1.getTimeJoined().toString().substring(0,10) + "\n" +
+                        member2.getTimeJoined().toString().substring(0,10);
+                embed.addField("🛬 Date of Arrival 🛬", date, true);
+                embed.addBlankField(false);
+                // Status comparison
+                String onlineStatus = member1.getUser().getName() + " :   " + member1.getOnlineStatus().name() + "\n" +
+                        member2.getUser().getName() + " :   " + member2.getOnlineStatus().name();
+                embed.addField("🟢 🌙 Status 💤 ⛔", onlineStatus, true);
+
+                // Starting date of boosting time for a member.
+                String boostingTime1;
+                String boostingTime2;
+                if (member1.getTimeBoosted() != null){
+                    // keeps yyyy-mm-dd
+                    boostingTime1 = member1.getTimeBoosted().toString().substring(0,10);
+                }else{
+                    boostingTime1 = "Currently not boosting";
+                }
+
+                if (member2.getTimeBoosted() != null){
+                    // keeps yyyy-mm-dd
+                    boostingTime2 = member2.getTimeBoosted().toString().substring(0,10);
+                }else{
+                    boostingTime2 = "Currently not boosting";
+                }
+
+                embed.addField("💎 Nitro Boosting 💎", boostingTime1 + "\n" + boostingTime2, true);
+
+                embed.addBlankField(false);
+
+                // Roles comparison of members
+                List<String> member1Roles = new ArrayList<>();
+                List<String> member2Roles = new ArrayList<>();
+
+                member1Roles.add("""
+                        ```diff""");
+                member2Roles.add("""
+                        ```diff""");
+                for (Role role : member1.getRoles()){
+                    member1Roles.add(role.getName());
+                }
+
+                for (Role role : member2.getRoles()){
+                    member2Roles.add(role.getName());
+                }
+
+                member1Roles.add("```");
+                member2Roles.add("```");
+
+                embed.addField( member1.getUser().getName() + "' Roles 🐱‍👤", String.join("\n", member1Roles), true);
+                embed.addField( member2.getUser().getName() + "' Roles 🐱‍👓", String.join("\n", member2Roles), true);
+
+
+                event.reply(embed.build());
+
+        }
+
     }
 }

--- a/src/main/java/pw/chew/chewbotcca/commands/DiffCommand.java
+++ b/src/main/java/pw/chew/chewbotcca/commands/DiffCommand.java
@@ -178,7 +178,7 @@ public class DiffCommand extends Command {
         }
 
         /**
-         * Helper method for %^diff role command about a role's info state
+         * Helper method for %^diff role command about a role's info state.
          *
          * @param yes if it's green or not
          * @return a green sign if true, red if false

--- a/src/main/java/pw/chew/chewbotcca/commands/DiffCommand.java
+++ b/src/main/java/pw/chew/chewbotcca/commands/DiffCommand.java
@@ -83,7 +83,7 @@ public class DiffCommand extends Command {
             EmbedBuilder embed = new EmbedBuilder()
                     .setTitle("Comparing roles")
                     .setDescription("Comparing name, color, permissions, and other information.\n" +
-                        "Base role: " + base.getName() + " ( " + base.getId()  + " ) " + "\n" +
+                            "Base role: " + base.getName() + " ( " + base.getId() + " ) " + "\n" +
                             "Compare role: " + compare.getName() + " ( " + compare.getId() + " ) ");
 
             if (base.getName().equals(compare.getName())) {
@@ -114,7 +114,7 @@ public class DiffCommand extends Command {
                     Bot role
                     Boost role
                     Integration role""";
-            embed.addField("Information",information,true);
+            embed.addField("Information", information, true);
 
             List<String> baseInfo = new ArrayList<>();
             baseInfo.add(getInfoState(base.isHoisted()));
@@ -123,7 +123,7 @@ public class DiffCommand extends Command {
             baseInfo.add(getInfoState(base.getTags().isBoost()));
             baseInfo.add(getInfoState(base.getTags().isIntegration()));
 
-            embed.addField(base.getName(),String.join("\n", baseInfo),true);
+            embed.addField(base.getName(), String.join("\n", baseInfo), true);
 
             List<String> compareInfo = new ArrayList<>();
             compareInfo.add(getInfoState(compare.isHoisted()));
@@ -132,8 +132,7 @@ public class DiffCommand extends Command {
             compareInfo.add(getInfoState(compare.getTags().isBoost()));
             compareInfo.add(getInfoState(compare.getTags().isIntegration()));
 
-            embed.addField(compare.getName(),String.join("\n", compareInfo),true);
-
+            embed.addField(compare.getName(), String.join("\n", compareInfo), true);
 
 
             if (base.getPermissionsRaw() == compare.getPermissionsRaw()) {
@@ -158,9 +157,9 @@ public class DiffCommand extends Command {
                 List<String> perms = new ArrayList<>();
 
                 perms.add("""
-                    + means compare role has the permission, and base doesn't.
-                    - means compare role doesn't have the perm, but base does.
-                    ```diff""");
+                        + means compare role has the permission, and base doesn't.
+                        - means compare role doesn't have the perm, but base does.
+                        ```diff""");
 
                 for (Permission perm : compareOnly) {
                     perms.add("+ " + perm.getName());
@@ -180,26 +179,28 @@ public class DiffCommand extends Command {
 
         /**
          * Helper method for %^diff role command about a role's info state
+         *
          * @param yes if it's green or not
          * @return a green sign if true, red if false
          */
         private String getInfoState(boolean yes) {
             if (yes) {
-                return "\uD83D\uDFE2" ;
+                return "\uD83D\uDFE2";
             } else {
-                return "\uD83D\uDD34" ;
+                return "\uD83D\uDD34";
             }
         }
 
         /**
          * Source: https://stackoverflow.com/questions/3607858/convert-a-rgb-color-value-to-a-hexadecimal-string
          * Function that converts RGB values to hexadecimal code.
-         * @param red red value of color
+         *
+         * @param red   red value of color
          * @param green green value of color
-         * @param blue blue value of color
+         * @param blue  blue value of color
          * @return the hexadecimal code of the color
          */
-        private String colorToHex(int red, int green, int blue){
+        private String colorToHex(int red, int green, int blue) {
             return String.format("#%02x%02x%02x", red, green, blue);
         }
     }
@@ -208,7 +209,7 @@ public class DiffCommand extends Command {
      * Compares members
      * Takes as input 2 mentioned members. Example diff member @random @random2
      */
-    private static class CompareMembersSubCommand extends Command{
+    private static class CompareMembersSubCommand extends Command {
 
         public CompareMembersSubCommand() {
             this.name = "member";
@@ -235,7 +236,7 @@ public class DiffCommand extends Command {
             EmbedBuilder embed = new EmbedBuilder()
                     .setTitle("Comparing members")
                     .setDescription("Comparing time joined, time boosted, roles and other information.\n" +
-                        "Base member: " + base.getUser().getName() + " ( " + base.getUser().getAsTag() + " ) " + "\n" +
+                            "Base member: " + base.getUser().getName() + " ( " + base.getUser().getAsTag() + " ) " + "\n" +
                             "Compare member : " + compare.getUser().getName() + " ( " + compare.getUser().getAsTag() + " ) ");
 
 
@@ -245,8 +246,8 @@ public class DiffCommand extends Command {
             embed.addField("Name", names, true);
 
             // Dates of arrival in server
-            String date = base.getTimeJoined().toString().substring(0,10) + "\n" +
-                    compare.getTimeJoined().toString().substring(0,10);
+            String date = base.getTimeJoined().toString().substring(0, 10) + "\n" +
+                    compare.getTimeJoined().toString().substring(0, 10);
             embed.addField(" Date of Arrival ", date, true);
             embed.addBlankField(false);
 
@@ -258,17 +259,17 @@ public class DiffCommand extends Command {
             // Starting date of boosting time for a member.
             String baseBoostingTime;
             String compareBoostingTime;
-            if (base.getTimeBoosted() != null){
+            if (base.getTimeBoosted() != null) {
                 // keeps yyyy-mm-dd
-                baseBoostingTime = "Boosting since : " + base.getTimeBoosted().toString().substring(0,10);
-            }else{
+                baseBoostingTime = "Boosting since : " + base.getTimeBoosted().toString().substring(0, 10);
+            } else {
                 baseBoostingTime = "Currently not boosting";
             }
 
-            if (compare.getTimeBoosted() != null){
+            if (compare.getTimeBoosted() != null) {
                 // keeps yyyy-mm-dd
-                compareBoostingTime = "Boosting since : " + compare.getTimeBoosted().toString().substring(0,10);
-            }else{
+                compareBoostingTime = "Boosting since : " + compare.getTimeBoosted().toString().substring(0, 10);
+            } else {
                 compareBoostingTime = "Currently not boosting";
             }
 
@@ -284,19 +285,19 @@ public class DiffCommand extends Command {
                     ```diff""");
             compareRoles.add("""
                     ```diff""");
-            for (Role role : base.getRoles()){
+            for (Role role : base.getRoles()) {
                 baseRoles.add(role.getName());
             }
 
-            for (Role role : compare.getRoles()){
+            for (Role role : compare.getRoles()) {
                 compareRoles.add(role.getName());
             }
 
             baseRoles.add("```");
             compareRoles.add("```");
 
-            embed.addField( base.getUser().getName() + "' Roles ", String.join("\n", baseRoles), true);
-            embed.addField( compare.getUser().getName() + "' Roles ", String.join("\n", compareRoles), true);
+            embed.addField(base.getUser().getName() + "' Roles ", String.join("\n", baseRoles), true);
+            embed.addField(compare.getUser().getName() + "' Roles ", String.join("\n", compareRoles), true);
 
 
             event.reply(embed.build());


### PR DESCRIPTION
Minor changes to role comparison
New command accepts string arguments as the roles and
not role ID's  anymore. Color seems kinda weird.

New sub-command compare that compares member's
date of arrival, date since last nitro boost,
names, status and roles.

Example: diff member Query#1234 random#4567

Also added thumbnail and color in embed builders