### PR TITLE
Add support for slash commands

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,16 +30,16 @@
         </repository>
         <repository>
             <id>chew-m2</id>
-            <url>https://m2.chew.pro/snapshots</url>
+            <url>https://m2.chew.pro/releases</url>
         </repository>
     </repositories>
 
     <dependencies>
         <!-- The JDA API... finally putting the "Discord Bot" in "Chewbotcca Discord Bot" -->
         <dependency>
-            <groupId>com.github.dv8fromtheworld</groupId>
-            <artifactId>jda</artifactId>
-            <version>3846f8c</version>
+            <groupId>net.dv8tion</groupId>
+            <artifactId>JDA</artifactId>
+            <version>4.3.0_277</version>
             <scope>compile</scope>
             <exclusions>
                 <exclusion>
@@ -49,11 +49,11 @@
             </exclusions>
         </dependency>
 
-        <!-- The command wapper, well, my fork of it -->
+        <!-- The command wrapper, well, my fork of it -->
         <dependency>
             <groupId>pw.chew</groupId>
             <artifactId>jda-chewtils</artifactId>
-            <version>1.DEV</version>
+            <version>1.20.2</version>
             <scope>compile</scope>
             <type>pom</type>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
         <dependency>
             <groupId>pw.chew</groupId>
             <artifactId>jda-chewtils</artifactId>
-            <version>1.20.2</version>
+            <version>1.20.3</version>
             <scope>compile</scope>
             <type>pom</type>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -16,14 +16,6 @@
 
     <repositories>
         <repository>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
-            <id>jcenter</id>
-            <name>jcenter-bintray</name>
-            <url>https://jcenter.bintray.com</url>
-        </repository>
-        <repository>
             <id>dv8tion</id>
             <name>m2-dv8tion</name>
             <url>https://m2.dv8tion.net/releases</url>
@@ -36,22 +28,32 @@
             <id>chew-jenkins</id>
             <url>https://jenkins.chew.pw/plugin/repository/everything/</url>
         </repository>
+        <repository>
+            <id>chew-m2</id>
+            <url>https://m2.chew.pro/snapshots</url>
+        </repository>
     </repositories>
 
     <dependencies>
         <!-- The JDA API... finally putting the "Discord Bot" in "Chewbotcca Discord Bot" -->
         <dependency>
-            <groupId>net.dv8tion</groupId>
-            <artifactId>JDA</artifactId>
-            <version>4.2.1_259</version>
+            <groupId>com.github.dv8fromtheworld</groupId>
+            <artifactId>jda</artifactId>
+            <version>3846f8c</version>
             <scope>compile</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>club.minnced</groupId>
+                    <artifactId>opus-java</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <!-- The command wapper, well, my fork of it -->
         <dependency>
             <groupId>pw.chew</groupId>
             <artifactId>jda-chewtils</artifactId>
-            <version>1.18</version>
+            <version>1.DEV</version>
             <scope>compile</scope>
             <type>pom</type>
         </dependency>
@@ -84,7 +86,7 @@
         <dependency>
             <groupId>org.awaitility</groupId>
             <artifactId>awaitility</artifactId>
-            <version>4.0.3</version>
+            <version>4.1.0</version>
             <scope>compile</scope>
         </dependency>
 
@@ -100,7 +102,7 @@
         <dependency>
             <groupId>org.kohsuke</groupId>
             <artifactId>github-api</artifactId>
-            <version>1.127</version>
+            <version>1.129</version>
             <scope>compile</scope>
         </dependency>
 
@@ -150,7 +152,7 @@
         <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
-            <version>8.0.24</version>
+            <version>8.0.25</version>
         </dependency>
     </dependencies>
 

--- a/src/main/java/pw/chew/chewbotcca/Main.java
+++ b/src/main/java/pw/chew/chewbotcca/Main.java
@@ -114,7 +114,7 @@ public class Main {
         client.addSlashCommands(getSlashCommands());
 
         // Temporary measure to test Slash Commands
-        client.forceGuildOnly("148195924567392257");
+        client.forceGuildOnly(PropertiesManager.forceGuildId());
         client.setManualUpsert(true);
 
         // Finalize the command client

--- a/src/main/java/pw/chew/chewbotcca/Main.java
+++ b/src/main/java/pw/chew/chewbotcca/Main.java
@@ -155,8 +155,8 @@ public class Main {
         List<Command> commands = new ArrayList<>();
 
         for (Class<? extends Command> theClass : subTypes) {
-            // Don't load SubCommands
-            if (theClass.getName().contains("SubCommand"))
+            // Don't load SubCommands or SlashCommands
+            if (theClass.getName().contains("SubCommand") || theClass.getName().contains("SlashCommand"))
                 continue;
             try {
                 commands.add(theClass.getDeclaredConstructor().newInstance());

--- a/src/main/java/pw/chew/chewbotcca/Main.java
+++ b/src/main/java/pw/chew/chewbotcca/Main.java
@@ -174,7 +174,7 @@ public class Main {
      *
      * @return an array of commands
      */
-    public static SlashCommand[] getSlashCommands() throws IllegalAccessException, InstantiationException, NoSuchMethodException, InvocationTargetException {
+    private static SlashCommand[] getSlashCommands() throws IllegalAccessException, InstantiationException, NoSuchMethodException, InvocationTargetException {
         Reflections reflections = new Reflections("pw.chew.chewbotcca.commands");
         Set<Class<? extends SlashCommand>> subTypes = reflections.getSubTypesOf(SlashCommand.class);
         List<SlashCommand> commands = new ArrayList<>();

--- a/src/main/java/pw/chew/chewbotcca/commands/bot/FeedbackCommand.java
+++ b/src/main/java/pw/chew/chewbotcca/commands/bot/FeedbackCommand.java
@@ -16,42 +16,84 @@
  */
 package pw.chew.chewbotcca.commands.bot;
 
-import com.jagrosh.jdautilities.command.Command;
 import com.jagrosh.jdautilities.command.CommandEvent;
+import com.jagrosh.jdautilities.command.SlashCommand;
 import net.dv8tion.jda.api.EmbedBuilder;
+import net.dv8tion.jda.api.JDA;
+import net.dv8tion.jda.api.entities.MessageEmbed;
+import net.dv8tion.jda.api.entities.TextChannel;
+import net.dv8tion.jda.api.entities.User;
+import net.dv8tion.jda.api.events.interaction.SlashCommandEvent;
+import net.dv8tion.jda.api.interactions.commands.OptionType;
+import net.dv8tion.jda.api.interactions.commands.build.OptionData;
+import pw.chew.chewbotcca.util.ResponseHelper;
 
 import java.awt.Color;
 import java.time.Instant;
-import java.util.Objects;
+import java.util.Collections;
 
 // %^feedback command
-public class FeedbackCommand extends Command {
+public class FeedbackCommand extends SlashCommand {
 
     public FeedbackCommand() {
         this.name = "feedback";
+        this.help = "Leave some feedback about the bot";
         this.cooldown = 30;
         this.cooldownScope = CooldownScope.USER;
         this.guildOnly = false;
+        this.options = Collections.singletonList(
+            new OptionData(OptionType.STRING, "feedback", "The feedback you want to leave").setRequired(true)
+        );
+    }
+
+    @Override
+    protected void execute(SlashCommandEvent event) {
+        try {
+            var feedback = event.getOption("feedback").getAsString();
+            TextChannel feedbackChannel = retrieveFeedbackChannel(event.getJDA());
+            feedbackChannel.sendMessage(generateFeedbackEmbed(feedback, event.getUser())).queue(
+                message -> event.reply("I have successfully sent the feedback! Feel free to see it on the help server with `/invite`")
+                    .setEphemeral(true)
+                    .queue()
+            );
+        } catch (IllegalArgumentException e) {
+            event.replyEmbeds(ResponseHelper.generateFailureEmbed(null, e.getMessage())).setEphemeral(true).queue();
+        }
+
     }
 
     @Override
     protected void execute(CommandEvent commandEvent) {
-        // Get args
-        var feedback = commandEvent.getArgs();
+        try {
+            var feedback = commandEvent.getArgs();
+            TextChannel feedbackChannel = retrieveFeedbackChannel(commandEvent.getJDA());
+            feedbackChannel.sendMessage(generateFeedbackEmbed(feedback, commandEvent.getAuthor())).queue(
+                message -> commandEvent.reply("I have successfully sent the feedback! Feel free to see it on the help server with `" + commandEvent.getPrefix() + "invite`")
+            );
+        } catch (IllegalArgumentException e) {
+            commandEvent.replyError(e.getMessage());
+        }
+    }
+
+    private MessageEmbed generateFeedbackEmbed(String feedback, User author) {
         if (feedback.length() < 10) {
-            commandEvent.reply("Your feedback is too short, how are we supposed to improve! Please enter at least 10 characters.");
-            return;
+            throw new IllegalArgumentException("Your feedback is too short, how are we supposed to improve! Please enter at least 10 characters.");
         }
         var embed = new EmbedBuilder();
         embed.setTitle("New Feedback!");
         embed.setColor(Color.decode("#6166A8"));
         embed.setDescription(feedback);
         embed.setTimestamp(Instant.now());
-        embed.setAuthor(commandEvent.getAuthor().getAsTag(), null, commandEvent.getAuthor().getAvatarUrl());
-        embed.setFooter("User ID: " + commandEvent.getAuthor().getId());
-        // Get the feedback channel and send
-        Objects.requireNonNull(commandEvent.getJDA().getTextChannelById("745164378659225651")).sendMessage(embed.build()).queue(
-            message -> commandEvent.reply("I have successfully sent the feedback! Feel free to see it on the help server with `" + commandEvent.getPrefix() + "invite`")
-        );
+        embed.setAuthor(author.getAsTag(), null, author.getAvatarUrl());
+        embed.setFooter("User ID: " + author.getId());
+        return embed.build();
+    }
+
+    private TextChannel retrieveFeedbackChannel(JDA jda) {
+        TextChannel feedbackChannel = jda.getTextChannelById("745164378659225651");
+        if (feedbackChannel == null) {
+            throw new IllegalArgumentException("Could not find feedback channel!");
+        }
+        return feedbackChannel;
     }
 }

--- a/src/main/java/pw/chew/chewbotcca/commands/bot/FeedbackCommand.java
+++ b/src/main/java/pw/chew/chewbotcca/commands/bot/FeedbackCommand.java
@@ -49,7 +49,7 @@ public class FeedbackCommand extends SlashCommand {
     @Override
     protected void execute(SlashCommandEvent event) {
         try {
-            var feedback = event.getOption("feedback").getAsString();
+            var feedback = ResponseHelper.guaranteeStringOption(event, "feedback", "");
             TextChannel feedbackChannel = retrieveFeedbackChannel(event.getJDA());
             feedbackChannel.sendMessage(generateFeedbackEmbed(feedback, event.getUser())).queue(
                 message -> event.reply("I have successfully sent the feedback! Feel free to see it on the help server with `/invite`")

--- a/src/main/java/pw/chew/chewbotcca/commands/bot/HelpCommand.java
+++ b/src/main/java/pw/chew/chewbotcca/commands/bot/HelpCommand.java
@@ -16,19 +16,25 @@
  */
 package pw.chew.chewbotcca.commands.bot;
 
-import com.jagrosh.jdautilities.command.Command;
 import com.jagrosh.jdautilities.command.CommandEvent;
+import com.jagrosh.jdautilities.command.SlashCommand;
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.Permission;
 import net.dv8tion.jda.api.entities.MessageEmbed;
+import net.dv8tion.jda.api.events.interaction.SlashCommandEvent;
 
 // %^help command
-public class HelpCommand extends Command {
+public class HelpCommand extends SlashCommand {
     public HelpCommand() {
         this.name = "help";
         this.help = "Get Help with the bot";
         this.botPermissions = new Permission[]{Permission.MESSAGE_EMBED_LINKS};
         this.guildOnly = false;
+    }
+
+    @Override
+    protected void execute(SlashCommandEvent event) {
+        event.replyEmbeds(generateHelpEmbed("/")).queue();
     }
 
     @Override
@@ -38,7 +44,15 @@ public class HelpCommand extends Command {
         if (!commandEvent.getArgs().isEmpty()) {
             notice = "Psst, to view more info about a command, use `" + commandEvent.getPrefix() + "info command`!";
         }
-        MessageEmbed embed = new EmbedBuilder()
+        MessageEmbed embed = generateHelpEmbed(commandEvent.getPrefix());
+        if (notice == null)
+            commandEvent.getChannel().sendMessage(embed).queue();
+        else
+            commandEvent.getChannel().sendMessage(notice).embed(embed).queue();
+    }
+
+    private MessageEmbed generateHelpEmbed(String prefix) {
+        return new EmbedBuilder()
             .setTitle("Welcome to the Chewbotcca Discord Bot")
             .setColor(0xd084)
             .setDescription("""
@@ -48,11 +62,7 @@ public class HelpCommand extends Command {
             .addField("Commands", "You can find all my commands [here](https://chew.pw/chewbotcca/discord/commands)", true)
             .addField("Invite me!", "You can invite me to your server with [this link](https://discord.com/oauth2/authorize?client_id=604362556668248095&scope=bot&permissions=0).", true)
             .addField("Help Server", "Click [me](https://discord.gg/UjxQ3Bh) to join the help server.", true)
-            .addField("More Bot Stats", "Run `" + commandEvent.getPrefix() + "stats` to see more stats!", true)
+            .addField("More Bot Stats", "Run `" + prefix + "stats` to see more stats!", true)
             .build();
-        if (notice == null)
-            commandEvent.getChannel().sendMessage(embed).queue();
-        else
-            commandEvent.getChannel().sendMessage(notice).embed(embed).queue();
     }
 }

--- a/src/main/java/pw/chew/chewbotcca/commands/bot/InviteCommand.java
+++ b/src/main/java/pw/chew/chewbotcca/commands/bot/InviteCommand.java
@@ -16,29 +16,41 @@
  */
 package pw.chew.chewbotcca.commands.bot;
 
-import com.jagrosh.jdautilities.command.Command;
 import com.jagrosh.jdautilities.command.CommandEvent;
+import com.jagrosh.jdautilities.command.SlashCommand;
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.Permission;
+import net.dv8tion.jda.api.entities.MessageEmbed;
+import net.dv8tion.jda.api.events.interaction.SlashCommandEvent;
 
 // %^invite command
-public class InviteCommand extends Command {
+public class InviteCommand extends SlashCommand {
     public InviteCommand() {
         this.name = "invite";
+        this.help = "Generate a link to invite me to your serve!";
         this.botPermissions = new Permission[]{Permission.MESSAGE_EMBED_LINKS};
         this.guildOnly = false;
     }
 
     @Override
+    protected void execute(SlashCommandEvent event) {
+        event.replyEmbeds(generateInviteEmbed()).queue();
+    }
+
+    @Override
     protected void execute(CommandEvent commandEvent) {
-        commandEvent.reply(new EmbedBuilder()
-                .setTitle("Invite me!")
-                .setDescription("""
+        commandEvent.reply(generateInviteEmbed());
+    }
+
+    private MessageEmbed generateInviteEmbed() {
+        return new EmbedBuilder()
+            .setTitle("Invite me!")
+            .setDescription("""
                     [Click me to invite me to your server (recommended)](https://discord.com/api/oauth2/authorize?client_id=604362556668248095&permissions=939879492&scope=bot%20applications.commands)!
                     [Click me to invite me to your server (admin)](https://discord.com/api/oauth2/authorize?client_id=604362556668248095&permissions=8&scope=bot%20applications.commands)!
                     
                     [Need help? Click me to join my help server](https://discord.gg/UjxQ3Bh)!
                     
-                    [Sponsored: Click me to get a VPS from SkySilk Cloud Services](https://www.skysilk.com/ref/4PRQpuQraD)!""").build());
+                    [Sponsored: Click me to get a VPS from SkySilk Cloud Services](https://www.skysilk.com/ref/4PRQpuQraD)!""").build();
     }
 }

--- a/src/main/java/pw/chew/chewbotcca/commands/bot/PingCommand.java
+++ b/src/main/java/pw/chew/chewbotcca/commands/bot/PingCommand.java
@@ -16,19 +16,26 @@
  */
 package pw.chew.chewbotcca.commands.bot;
 
-import com.jagrosh.jdautilities.command.Command;
 import com.jagrosh.jdautilities.command.CommandEvent;
+import com.jagrosh.jdautilities.command.SlashCommand;
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.Permission;
+import net.dv8tion.jda.api.events.interaction.SlashCommandEvent;
 
 // %^ping command
-public class PingCommand extends Command {
+public class PingCommand extends SlashCommand {
 
     public PingCommand() {
         this.name = "ping";
         this.help = "Ping the bot";
         this.botPermissions = new Permission[]{Permission.MESSAGE_EMBED_LINKS};
         this.guildOnly = false;
+    }
+
+    @Override
+    protected void execute(SlashCommandEvent slashCommandEvent) {
+        // Has to be simpler due to interaction weirdness
+        slashCommandEvent.reply("Pong!").setEphemeral(true).queue();
     }
 
     @Override

--- a/src/main/java/pw/chew/chewbotcca/commands/bot/PrivacyCommand.java
+++ b/src/main/java/pw/chew/chewbotcca/commands/bot/PrivacyCommand.java
@@ -16,14 +16,21 @@
  */
 package pw.chew.chewbotcca.commands.bot;
 
-import com.jagrosh.jdautilities.command.Command;
 import com.jagrosh.jdautilities.command.CommandEvent;
+import com.jagrosh.jdautilities.command.SlashCommand;
+import net.dv8tion.jda.api.events.interaction.SlashCommandEvent;
 
-public class PrivacyCommand extends Command {
+public class PrivacyCommand extends SlashCommand {
 
     public PrivacyCommand() {
         this.name = "privacy";
+        this.help = "Find a link to Chewbotcca's privacy policy";
         this.guildOnly = false;
+    }
+
+    @Override
+    protected void execute(SlashCommandEvent event) {
+        event.reply("You can view the Chewbotcca privacy policy here: https://chew.pw/chewbotcca/discord/privacy").setEphemeral(true).queue();
     }
 
     @Override

--- a/src/main/java/pw/chew/chewbotcca/commands/bot/StatsCommand.java
+++ b/src/main/java/pw/chew/chewbotcca/commands/bot/StatsCommand.java
@@ -16,38 +16,50 @@
  */
 package pw.chew.chewbotcca.commands.bot;
 
-import com.jagrosh.jdautilities.command.Command;
 import com.jagrosh.jdautilities.command.CommandEvent;
+import com.jagrosh.jdautilities.command.SlashCommand;
 import net.dv8tion.jda.api.EmbedBuilder;
+import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.JDAInfo;
 import net.dv8tion.jda.api.Permission;
+import net.dv8tion.jda.api.entities.MessageEmbed;
+import net.dv8tion.jda.api.events.interaction.SlashCommandEvent;
 import pw.chew.chewbotcca.util.DateTime;
 
 import java.time.Instant;
 
 // %^stats command
-public class StatsCommand extends Command {
+public class StatsCommand extends SlashCommand {
     private final static Instant startTime = Instant.now();
 
     public StatsCommand() {
         this.name = "stats";
+        this.help = "Cool stats about the bot!";
         this.botPermissions = new Permission[]{Permission.MESSAGE_EMBED_LINKS};
         this.guildOnly = false;
     }
 
     @Override
+    protected void execute(SlashCommandEvent event) {
+        event.replyEmbeds(generateStatsEmbed(event.getJDA())).queue();
+    }
+
+    @Override
     protected void execute(CommandEvent commandEvent) {
-        commandEvent.reply(new EmbedBuilder()
-                .setTitle("Chewbotcca - A basic, yet functioning, discord bot")
-                .addField("Author", "<@!476488167042580481>", true)
-                .addField("Code", "[View code on GitHub](https://github.com/Chewbotcca/Discord)", true)
-                .addField("Library", "[JDA " + JDAInfo.VERSION + "](" + JDAInfo.GITHUB + ")", true)
-                // Convert the time difference into a time ago
-                .addField("Uptime", DateTime.timeAgo(Instant.now().toEpochMilli() - startTime.toEpochMilli()), true)
-                // Get the server count. NOT GUILD NOT GUILD NOT GUILD
-                .addField("Servers", String.valueOf(commandEvent.getJDA().getGuildCache().size()), true)
-                .setColor(0xd084)
-                .build()
-        );
+        commandEvent.reply(generateStatsEmbed(commandEvent.getJDA()));
+    }
+
+    private MessageEmbed generateStatsEmbed(JDA jda) {
+        return new EmbedBuilder()
+            .setTitle("Chewbotcca - A basic, yet functioning, discord bot")
+            .addField("Author", "<@!476488167042580481>", true)
+            .addField("Code", "[View code on GitHub](https://github.com/Chewbotcca/Discord)", true)
+            .addField("Library", "[JDA " + JDAInfo.VERSION + "](" + JDAInfo.GITHUB + ")", true)
+            // Convert the time difference into a time ago
+            .addField("Uptime", DateTime.timeAgo(Instant.now().toEpochMilli() - startTime.toEpochMilli()), true)
+            // Get the server count. NOT GUILD NOT GUILD NOT GUILD
+            .addField("Servers", String.valueOf(jda.getGuildCache().size()), true)
+            .setColor(0xd084)
+            .build();
     }
 }

--- a/src/main/java/pw/chew/chewbotcca/commands/fun/APODCommand.java
+++ b/src/main/java/pw/chew/chewbotcca/commands/fun/APODCommand.java
@@ -82,9 +82,10 @@ public class APODCommand extends SlashCommand {
             if (input.length < 3) {
                 throw new IllegalArgumentException("Invalid format! Must be MM/DD/YYYY");
             }
-            date = getDateURL(input);
-            if (date == null) {
-                throw new IllegalArgumentException("Invalid date! Range is June 16th, 1995 to today!");
+            try {
+                date = getDateURL(input);
+            } catch (IllegalArgumentException e) {
+                throw new IllegalArgumentException("Error occurred: " + e.getMessage() + " Range is June 16th, 1995 to today!");
             }
         }
 
@@ -140,16 +141,16 @@ public class APODCommand extends SlashCommand {
 
         // No APOD prior to 1995
         if (year < 1995)
-            return null;
+            throw new IllegalArgumentException("Year must not be prior to 1995.");
         // No APOD for the future
         if (year > current.getYear())
-            return null;
+            throw new IllegalArgumentException("Year must not be later than current year.");
         if (year == current.getYear()) {
             if (month > current.getMonthValue())
-                return null;
+                throw new IllegalArgumentException("Month must not be later than current month.");
             if (month == current.getMonthValue()) {
                 if (day > current.getDayOfMonth())
-                    return null;
+                    throw new IllegalArgumentException("Day must not be later than current day.");
             }
         }
         String yearString = String.join("", Arrays.asList(String.valueOf(year).split("")).subList(2, 4));

--- a/src/main/java/pw/chew/chewbotcca/commands/fun/APODCommand.java
+++ b/src/main/java/pw/chew/chewbotcca/commands/fun/APODCommand.java
@@ -16,17 +16,21 @@
  */
 package pw.chew.chewbotcca.commands.fun;
 
-import com.jagrosh.jdautilities.command.Command;
 import com.jagrosh.jdautilities.command.CommandEvent;
+import com.jagrosh.jdautilities.command.SlashCommand;
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.Permission;
-import net.dv8tion.jda.api.entities.MessageChannel;
+import net.dv8tion.jda.api.entities.MessageEmbed;
+import net.dv8tion.jda.api.events.interaction.SlashCommandEvent;
+import net.dv8tion.jda.api.interactions.commands.OptionType;
+import net.dv8tion.jda.api.interactions.commands.build.OptionData;
 import org.htmlcleaner.CleanerProperties;
 import org.htmlcleaner.DomSerializer;
 import org.htmlcleaner.HtmlCleaner;
 import org.htmlcleaner.TagNode;
 import org.w3c.dom.Document;
 import org.w3c.dom.Node;
+import pw.chew.chewbotcca.util.ResponseHelper;
 import pw.chew.chewbotcca.util.RestClient;
 
 import javax.xml.parsers.ParserConfigurationException;
@@ -38,34 +42,51 @@ import java.time.Instant;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.util.Arrays;
-import java.util.Date;
+import java.util.Collections;
 
-public class APODCommand extends Command {
+public class APODCommand extends SlashCommand {
 
     public APODCommand() {
         this.name = "apod";
+        this.help = "Show NASA's Astronomy Picture of the Day for today, or a specified date";
         this.aliases = new String[]{"dailyspace", "astropix", "apix"};
         this.botPermissions = new Permission[]{Permission.MESSAGE_EMBED_LINKS};
         this.guildOnly = false;
+        this.options = Collections.singletonList(
+            new OptionData(OptionType.STRING, "date", "The date in MM/DD/YYYY format, blank for today")
+        );
+    }
+
+    @Override
+    protected void execute(SlashCommandEvent event) {
+        try {
+            event.replyEmbeds(gatherPicture(ResponseHelper.guaranteeStringOption(event, "date", "astropix"))).queue();
+        } catch (IllegalArgumentException e) {
+            event.reply(e.getMessage()).setEphemeral(true).queue();
+        }
     }
 
     @Override
     protected void execute(CommandEvent event) {
-        String date = "astropix";
-        if (!event.getArgs().isBlank()) {
-            String[] input = event.getArgs().split("/");
+        event.getChannel().sendTyping().queue();
+        try {
+            event.reply(gatherPicture(event.getArgs()));
+        } catch (IllegalArgumentException e) {
+            event.reply(e.getMessage());
+        }
+    }
+
+    private MessageEmbed gatherPicture(String date) {
+        if (date.equals("astropix") || date.isBlank()) {
+            String[] input = date.split("/");
             if (input.length < 3) {
-                event.reply("Invalid format! Must be MM/DD/YYYY");
-                return;
+                throw new IllegalArgumentException("Invalid format! Must be MM/DD/YYYY");
             }
             date = getDateURL(input);
             if (date == null) {
-                event.reply("Invalid date! Range is June 16th, 1995 to today!");
-                return;
+                throw new IllegalArgumentException("Invalid date! Range is June 16th, 1995 to today!");
             }
         }
-
-        event.getChannel().sendTyping().queue();
 
         String url = String.format("https://apod.nasa.gov/apod/%s.html", date);
 
@@ -77,9 +98,8 @@ public class APODCommand extends Command {
         try {
             doc = new DomSerializer(new CleanerProperties()).createDOM(tagNode);
         } catch (ParserConfigurationException e) {
-            event.reply("Error configuring Parser!");
             e.printStackTrace();
-            return;
+            throw new IllegalArgumentException("Error configuring Parser!");
         }
 
         // Find the image
@@ -92,23 +112,20 @@ public class APODCommand extends Command {
             img += src.getAttributes().getNamedItem("src").toString().replace("src=", "").replace("\"", "");
         } catch (NullPointerException ignored) {
         } catch (XPathExpressionException e) {
-            event.reply("Error in XPath Expression!");
             e.printStackTrace();
-            return;
+            throw new IllegalArgumentException("Error in XPath Expression!");
         }
 
         // If 404 somehow
         if (img.equals("https://apod.nasa.gov/apod/")) {
-            event.reply("Invalid date! Range is June 16th, 1995 to today!");
-            return;
+            throw new IllegalArgumentException("Invalid date! Range is June 16th, 1995 to today!");
         }
 
-        MessageChannel channel = event.getChannel();
         EmbedBuilder embed = new EmbedBuilder();
         embed.setImage(img)
             .setAuthor("NASA Astronomy Picture of the Day")
             .setTitle(title, url);
-        channel.sendMessage(embed.build()).queue();
+        return embed.build();
     }
 
     private String getDateURL(String[] date) {
@@ -120,8 +137,6 @@ public class APODCommand extends Command {
         int year = Integer.parseInt(date[2]);
         if (year < 2000)
             year += 2000;
-
-        Date parse = new Date(year - 1900, month, day);
 
         // No APOD prior to 1995
         if (year < 1995)

--- a/src/main/java/pw/chew/chewbotcca/commands/fun/APODCommand.java
+++ b/src/main/java/pw/chew/chewbotcca/commands/fun/APODCommand.java
@@ -77,7 +77,7 @@ public class APODCommand extends SlashCommand {
     }
 
     private MessageEmbed gatherPicture(String date) {
-        if (date.equals("astropix") || date.isBlank()) {
+        if (!date.equals("astropix") || date.isBlank()) {
             String[] input = date.split("/");
             if (input.length < 3) {
                 throw new IllegalArgumentException("Invalid format! Must be MM/DD/YYYY");

--- a/src/main/java/pw/chew/chewbotcca/commands/fun/AcronymCommand.java
+++ b/src/main/java/pw/chew/chewbotcca/commands/fun/AcronymCommand.java
@@ -46,7 +46,7 @@ public class AcronymCommand extends SlashCommand {
             String phrase = Memory.getChewAPI().generateAcronym(acronym);
             event.reply("Acronym for " + acronym + " is " + phrase).queue();
         } catch (IllegalArgumentException e) {
-            event.reply("Args must only contain letters!").queue();
+            event.reply("Args must only contain letters!").setEphemeral(true).queue();
         }
     }
 

--- a/src/main/java/pw/chew/chewbotcca/commands/fun/AcronymCommand.java
+++ b/src/main/java/pw/chew/chewbotcca/commands/fun/AcronymCommand.java
@@ -16,16 +16,37 @@
  */
 package pw.chew.chewbotcca.commands.fun;
 
-import com.jagrosh.jdautilities.command.Command;
 import com.jagrosh.jdautilities.command.CommandEvent;
+import com.jagrosh.jdautilities.command.SlashCommand;
+import net.dv8tion.jda.api.events.interaction.SlashCommandEvent;
+import net.dv8tion.jda.api.interactions.commands.OptionType;
+import net.dv8tion.jda.api.interactions.commands.build.OptionData;
 import pw.chew.chewbotcca.objects.Memory;
 
+import java.util.Collections;
+
 // %^acronym command
-public class AcronymCommand extends Command {
+public class AcronymCommand extends SlashCommand {
 
     public AcronymCommand() {
         this.name = "acronym";
+        this.help = "Fill in an acronym (2% accuracy)";
         this.guildOnly = false;
+        this.options = Collections.singletonList(
+            new OptionData(OptionType.STRING, "acronym", "The acronym to fill").setRequired(true)
+        );
+    }
+
+    @Override
+    protected void execute(SlashCommandEvent event) {
+        // Get acronym and send if the acronym is valid
+        try {
+            String acronym = event.getOption("acronym").getAsString();
+            String phrase = Memory.getChewAPI().generateAcronym(acronym);
+            event.reply("Acronym for " + acronym + " is " + phrase).queue();
+        } catch (IllegalArgumentException e) {
+            event.reply("Args must only contain letters!").queue();
+        }
     }
 
     @Override

--- a/src/main/java/pw/chew/chewbotcca/commands/fun/AcronymCommand.java
+++ b/src/main/java/pw/chew/chewbotcca/commands/fun/AcronymCommand.java
@@ -22,6 +22,7 @@ import net.dv8tion.jda.api.events.interaction.SlashCommandEvent;
 import net.dv8tion.jda.api.interactions.commands.OptionType;
 import net.dv8tion.jda.api.interactions.commands.build.OptionData;
 import pw.chew.chewbotcca.objects.Memory;
+import pw.chew.chewbotcca.util.ResponseHelper;
 
 import java.util.Collections;
 
@@ -41,7 +42,7 @@ public class AcronymCommand extends SlashCommand {
     protected void execute(SlashCommandEvent event) {
         // Get acronym and send if the acronym is valid
         try {
-            String acronym = event.getOption("acronym").getAsString();
+            String acronym = ResponseHelper.guaranteeStringOption(event, "acronym", "");
             String phrase = Memory.getChewAPI().generateAcronym(acronym);
             event.reply("Acronym for " + acronym + " is " + phrase).queue();
         } catch (IllegalArgumentException e) {

--- a/src/main/java/pw/chew/chewbotcca/commands/fun/CatCommand.java
+++ b/src/main/java/pw/chew/chewbotcca/commands/fun/CatCommand.java
@@ -16,41 +16,50 @@
  */
 package pw.chew.chewbotcca.commands.fun;
 
-import com.jagrosh.jdautilities.command.Command;
 import com.jagrosh.jdautilities.command.CommandEvent;
+import com.jagrosh.jdautilities.command.SlashCommand;
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.Permission;
+import net.dv8tion.jda.api.entities.MessageEmbed;
+import net.dv8tion.jda.api.events.interaction.SlashCommandEvent;
 import org.json.JSONException;
 import org.json.JSONObject;
+import pw.chew.chewbotcca.util.ResponseHelper;
 import pw.chew.chewbotcca.util.RestClient;
 
 // %^cat command
-public class CatCommand extends Command {
+public class CatCommand extends SlashCommand {
 
     public CatCommand() {
         this.name = "cat";
+        this.help = "Get a very cute picture of a cat!";
         this.botPermissions = new Permission[]{Permission.MESSAGE_EMBED_LINKS};
         this.guildOnly = false;
     }
 
     @Override
+    protected void execute(SlashCommandEvent event) {
+        event.replyEmbeds(generateCatEmbed()).queue();
+    }
+
+    @Override
     protected void execute(CommandEvent commandEvent) {
+        commandEvent.reply(generateCatEmbed());
+    }
+
+    private MessageEmbed generateCatEmbed() {
         // Try to gather a cat from the Cat API
         try {
             String showcat = new JSONObject(RestClient.get("https://aws.random.cat/meow")).getString("file");
 
-            commandEvent.reply(new EmbedBuilder()
+            return (new EmbedBuilder()
                 .setTitle("Adorable.", showcat)
                 .setImage(showcat)
                 .build()
             );
         } catch (JSONException e) {
             // If cat collecting failed :(
-            commandEvent.reply(new EmbedBuilder()
-                .setTitle("Sad mews!")
-                .setDescription("The Cat API is not working. :( Try again later? :3")
-                .build()
-            );
+            return (ResponseHelper.generateFailureEmbed("Sad news!", "The Cat API is not working. :( Try again later? :3"));
         }
     }
 }

--- a/src/main/java/pw/chew/chewbotcca/commands/fun/CatFactCommand.java
+++ b/src/main/java/pw/chew/chewbotcca/commands/fun/CatFactCommand.java
@@ -16,28 +16,37 @@
  */
 package pw.chew.chewbotcca.commands.fun;
 
-import com.jagrosh.jdautilities.command.Command;
 import com.jagrosh.jdautilities.command.CommandEvent;
+import com.jagrosh.jdautilities.command.SlashCommand;
+import net.dv8tion.jda.api.events.interaction.SlashCommandEvent;
 import org.json.JSONObject;
 import pw.chew.chewbotcca.util.RestClient;
 
 // %^catfact command
-public class CatFactCommand extends Command {
+public class CatFactCommand extends SlashCommand {
 
     public CatFactCommand() {
         this.name = "catfact";
+        this.help = "Find a fun fact about our furry feline friends!";
         this.guildOnly = false;
     }
 
     @Override
+    protected void execute(SlashCommandEvent event) {
+        event.reply(getFact()).queue();
+    }
+
+    @Override
     protected void execute(CommandEvent commandEvent) {
+        commandEvent.reply(getFact());
+    }
+
+    private String getFact() {
         // Get a fact and respond with it
         JSONObject data = new JSONObject(RestClient.get("https://catfact.ninja/fact"));
         if (data.has("error")) {
-            commandEvent.reply("Could not get cat fact :cry: Error: " + data.getString("error"));
-            return;
+            return "Could not get cat fact :cry: Error: " + data.getString("error");
         }
-        String fact = data.getString("fact");
-        commandEvent.reply(fact);
+        return data.getString("fact");
     }
 }

--- a/src/main/java/pw/chew/chewbotcca/commands/fun/CoinFlipCommand.java
+++ b/src/main/java/pw/chew/chewbotcca/commands/fun/CoinFlipCommand.java
@@ -16,24 +16,36 @@
  */
 package pw.chew.chewbotcca.commands.fun;
 
-import com.jagrosh.jdautilities.command.Command;
 import com.jagrosh.jdautilities.command.CommandEvent;
+import com.jagrosh.jdautilities.command.SlashCommand;
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.Permission;
+import net.dv8tion.jda.api.entities.MessageEmbed;
+import net.dv8tion.jda.api.events.interaction.SlashCommandEvent;
 
 import static pw.chew.chewbotcca.commands.fun.EightBallCommand.getRandom;
 
-public class CoinFlipCommand extends Command {
+public class CoinFlipCommand extends SlashCommand {
 
     public CoinFlipCommand() {
         this.name = "coinflip";
+        this.help = "Flip a coin";
         this.aliases = new String[]{"flip"};
         this.botPermissions = new Permission[]{Permission.MESSAGE_EMBED_LINKS};
         this.guildOnly = false;
     }
 
     @Override
+    protected void execute(SlashCommandEvent event) {
+        event.replyEmbeds(flipCoin()).queue();
+    }
+
+    @Override
     protected void execute(CommandEvent event) {
+        event.reply(flipCoin());
+    }
+
+    private MessageEmbed flipCoin() {
         String first = getRandom(new String[]{
             "I flipped a coin, and it landed on",
             "I threw the coin into the air and it finally landed on",
@@ -44,6 +56,6 @@ public class CoinFlipCommand extends Command {
         EmbedBuilder e = new EmbedBuilder();
         e.setTitle("Coin Flip");
         e.setDescription(first + " **" + headsOrTails + "**!");
-        event.reply(e.build());
+        return e.build();
     }
 }

--- a/src/main/java/pw/chew/chewbotcca/commands/fun/DogCommand.java
+++ b/src/main/java/pw/chew/chewbotcca/commands/fun/DogCommand.java
@@ -16,20 +16,34 @@
  */
 package pw.chew.chewbotcca.commands.fun;
 
-import com.jagrosh.jdautilities.command.Command;
 import com.jagrosh.jdautilities.command.CommandEvent;
+import com.jagrosh.jdautilities.command.SlashCommand;
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.Permission;
+import net.dv8tion.jda.api.events.interaction.SlashCommandEvent;
 import org.json.JSONObject;
 import pw.chew.chewbotcca.util.RestClient;
 
 // %^dog command
-public class DogCommand extends Command {
+public class DogCommand extends SlashCommand {
 
     public DogCommand() {
         this.name = "dog";
+        this.help = "Gets a random dog picture! Bark, woof, purr?";
         this.botPermissions = new Permission[]{Permission.MESSAGE_EMBED_LINKS};
         this.guildOnly = false;
+    }
+
+    @Override
+    protected void execute(SlashCommandEvent event) {
+        // Get a dog and bark it, i mean send it, am not furry i swear
+        String dog = new JSONObject(RestClient.get("https://random.dog/woof.json")).getString("url");
+
+        event.replyEmbeds(new EmbedBuilder()
+            .setTitle("Adorable.", dog)
+            .setImage(dog)
+            .build()
+        ).queue();
     }
 
     @Override
@@ -38,9 +52,9 @@ public class DogCommand extends Command {
         String dog = new JSONObject(RestClient.get("https://random.dog/woof.json")).getString("url");
 
         commandEvent.reply(new EmbedBuilder()
-                .setTitle("Adorable.", dog)
-                .setImage(dog)
-                .build()
+            .setTitle("Adorable.", dog)
+            .setImage(dog)
+            .build()
         );
     }
 }

--- a/src/main/java/pw/chew/chewbotcca/commands/fun/EightBallCommand.java
+++ b/src/main/java/pw/chew/chewbotcca/commands/fun/EightBallCommand.java
@@ -16,16 +16,21 @@
  */
 package pw.chew.chewbotcca.commands.fun;
 
-import com.jagrosh.jdautilities.command.Command;
 import com.jagrosh.jdautilities.command.CommandEvent;
+import com.jagrosh.jdautilities.command.SlashCommand;
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.Permission;
+import net.dv8tion.jda.api.entities.MessageEmbed;
+import net.dv8tion.jda.api.events.interaction.SlashCommandEvent;
+import net.dv8tion.jda.api.interactions.commands.OptionType;
+import net.dv8tion.jda.api.interactions.commands.build.OptionData;
 
 import java.awt.Color;
+import java.util.Collections;
 import java.util.Random;
 
 // %^8ball command
-public class EightBallCommand extends Command {
+public class EightBallCommand extends SlashCommand {
     // The good responses
     final String[] goodResponses = new String[]{
             "As I see it, yes",
@@ -67,14 +72,27 @@ public class EightBallCommand extends Command {
 
     public EightBallCommand() {
         this.name = "8ball";
+        this.help = "Ask the magic 8ball a question!";
         this.botPermissions = new Permission[]{Permission.MESSAGE_EMBED_LINKS};
         this.guildOnly = false;
+        this.options = Collections.singletonList(
+            new OptionData(OptionType.STRING, "question", "The question to ask the eight ball").setRequired(true)
+        );
+    }
+
+    @Override
+    protected void execute(SlashCommandEvent event) {
+        event.replyEmbeds(generateEmbed(event.getOption("question").getAsString())).queue();
     }
 
     @Override
     protected void execute(CommandEvent commandEvent) {
         // Get the question, doesn't matter what they said but we'll send it back to them
         String question = commandEvent.getArgs();
+        commandEvent.reply(generateEmbed(question));
+    }
+
+    private MessageEmbed generateEmbed(String question) {
         // Pick a number between 0 and 2 inclusive
         int response = rand.nextInt(3);
         EmbedBuilder e = new EmbedBuilder();
@@ -98,7 +116,7 @@ public class EightBallCommand extends Command {
         }
         // Finish and send embed
         e.addField(":8ball: 8ball says", answer, false);
-        commandEvent.reply(e.build());
+        return e.build();
     }
 
     // Method to get a random string from an array

--- a/src/main/java/pw/chew/chewbotcca/commands/fun/EightBallCommand.java
+++ b/src/main/java/pw/chew/chewbotcca/commands/fun/EightBallCommand.java
@@ -24,6 +24,7 @@ import net.dv8tion.jda.api.entities.MessageEmbed;
 import net.dv8tion.jda.api.events.interaction.SlashCommandEvent;
 import net.dv8tion.jda.api.interactions.commands.OptionType;
 import net.dv8tion.jda.api.interactions.commands.build.OptionData;
+import pw.chew.chewbotcca.util.ResponseHelper;
 
 import java.awt.Color;
 import java.util.Collections;
@@ -82,7 +83,7 @@ public class EightBallCommand extends SlashCommand {
 
     @Override
     protected void execute(SlashCommandEvent event) {
-        event.replyEmbeds(generateEmbed(event.getOption("question").getAsString())).queue();
+        event.replyEmbeds(generateEmbed(ResponseHelper.guaranteeStringOption(event, "question", ""))).queue();
     }
 
     @Override

--- a/src/main/java/pw/chew/chewbotcca/commands/fun/NumberFactCommand.java
+++ b/src/main/java/pw/chew/chewbotcca/commands/fun/NumberFactCommand.java
@@ -16,18 +16,43 @@
  */
 package pw.chew.chewbotcca.commands.fun;
 
-import com.jagrosh.jdautilities.command.Command;
 import com.jagrosh.jdautilities.command.CommandEvent;
+import com.jagrosh.jdautilities.command.SlashCommand;
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.Permission;
+import net.dv8tion.jda.api.entities.MessageEmbed;
+import net.dv8tion.jda.api.events.interaction.SlashCommandEvent;
+import net.dv8tion.jda.api.interactions.commands.OptionType;
+import net.dv8tion.jda.api.interactions.commands.build.OptionData;
+import pw.chew.chewbotcca.util.ResponseHelper;
 import pw.chew.chewbotcca.util.RestClient;
 
+import java.util.Arrays;
+
 // %^numberfact command
-public class NumberFactCommand extends Command {
+public class NumberFactCommand extends SlashCommand {
+
     public NumberFactCommand() {
         this.name = "numberfact";
+        this.help = "Find some cool and interesting facts about a number";
         this.botPermissions = new Permission[]{Permission.MESSAGE_EMBED_LINKS};
         this.guildOnly = false;
+        this.options = Arrays.asList(
+            new OptionData(OptionType.INTEGER, "number", "The number to get facts about").setRequired(true),
+            new OptionData(OptionType.STRING, "type", "The type of fact to return")
+                .addChoice("Trivia (default)", "trivia")
+                .addChoice("Math", "math")
+                .addChoice("Date", "date")
+                .addChoice("Year", "year")
+        );
+    }
+
+    @Override
+    protected void execute(SlashCommandEvent event) {
+        event.replyEmbeds(gatherFact(
+            ResponseHelper.guaranteeStringOption(event, "number", "0"),
+            ResponseHelper.guaranteeStringOption(event, "type", "trivia")
+        )).queue();
     }
 
     @Override
@@ -35,7 +60,7 @@ public class NumberFactCommand extends Command {
         // Get the arguments
         String[] args = commandEvent.getArgs().split(" ");
         // If there's no args
-        if(args.length == 0) {
+        if (args.length == 0) {
             commandEvent.reply("Please specify a number to find a fact for! Also, optionally specify what type of fact, choices: `trivia`, `year`, `date`, `math`.");
             return;
         }
@@ -49,12 +74,16 @@ public class NumberFactCommand extends Command {
         }
         // The type if specified
         String type;
-        if(args.length > 1) {
+        if (args.length > 1) {
             type = args[1].toLowerCase();
         } else {
             type = "trivia";
         }
 
+        commandEvent.reply(gatherFact(number, type));
+    }
+
+    private MessageEmbed gatherFact(String number, String type) {
         // Generate the url based off of the type
         String url = switch (type) {
             default -> "http://numbersapi.com/" + number + "?notfound=";
@@ -77,6 +106,6 @@ public class NumberFactCommand extends Command {
         if (!facto.split(" ")[0].equals(number) && !type.equals("date"))
             embed.setFooter("Your number didn't have a fact, so a number was approximated for you.");
 
-        commandEvent.reply(embed.build());
+        return embed.build();
     }
 }

--- a/src/main/java/pw/chew/chewbotcca/commands/fun/QRCodeCommand.java
+++ b/src/main/java/pw/chew/chewbotcca/commands/fun/QRCodeCommand.java
@@ -16,21 +16,42 @@
  */
 package pw.chew.chewbotcca.commands.fun;
 
-import com.jagrosh.jdautilities.command.Command;
 import com.jagrosh.jdautilities.command.CommandEvent;
+import com.jagrosh.jdautilities.command.SlashCommand;
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.Permission;
+import net.dv8tion.jda.api.events.interaction.SlashCommandEvent;
+import net.dv8tion.jda.api.interactions.commands.OptionType;
+import net.dv8tion.jda.api.interactions.commands.build.OptionData;
+import pw.chew.chewbotcca.util.ResponseHelper;
 
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
+import java.util.Collections;
 
 // %^qrcode command
-public class QRCodeCommand extends Command {
+public class QRCodeCommand extends SlashCommand {
+
     public QRCodeCommand() {
         this.name = "qrcode";
+        this.help = "Converts arguments into a QR Code";
         this.aliases = new String[]{"qr"};
         this.botPermissions = new Permission[]{Permission.MESSAGE_EMBED_LINKS};
         this.guildOnly = false;
+        this.options = Collections.singletonList(
+            new OptionData(OptionType.STRING, "data", "The data to convert into a QR Code").setRequired(true)
+        );
+    }
+
+    @Override
+    protected void execute(SlashCommandEvent event) {
+        // Get the query string
+        String code = ResponseHelper.guaranteeStringOption(event, "data", "");
+        event.replyEmbeds(new EmbedBuilder()
+            // Encode the input and return an image from google chart apis
+            .setImage("https://chart.apis.google.com/chart?chl=" + URLEncoder.encode(code, StandardCharsets.UTF_8) + "&chld=H|0&chs=500x500&cht=qr")
+            .build()
+        ).queue();
     }
 
     @Override
@@ -38,9 +59,9 @@ public class QRCodeCommand extends Command {
         // Get the query string
         String code = commandEvent.getArgs();
         commandEvent.reply(new EmbedBuilder()
-                // Encode the input and return an image from google chart apis
-                .setImage("https://chart.apis.google.com/chart?chl=" + URLEncoder.encode(code, StandardCharsets.UTF_8) + "&chld=H|0&chs=500x500&cht=qr")
-                .build()
+            // Encode the input and return an image from google chart apis
+            .setImage("https://chart.apis.google.com/chart?chl=" + URLEncoder.encode(code, StandardCharsets.UTF_8) + "&chld=H|0&chs=500x500&cht=qr")
+            .build()
         );
     }
 }

--- a/src/main/java/pw/chew/chewbotcca/commands/fun/RollCommand.java
+++ b/src/main/java/pw/chew/chewbotcca/commands/fun/RollCommand.java
@@ -56,6 +56,8 @@ public class RollCommand extends SlashCommand {
                     dice = (int) mapping.getAsLong();
                 case "sides":
                     sides = (int) mapping.getAsLong();
+                default:
+                    break;
             }
         }
 

--- a/src/main/java/pw/chew/chewbotcca/commands/fun/RollCommand.java
+++ b/src/main/java/pw/chew/chewbotcca/commands/fun/RollCommand.java
@@ -16,25 +16,61 @@
  */
 package pw.chew.chewbotcca.commands.fun;
 
-import com.jagrosh.jdautilities.command.Command;
 import com.jagrosh.jdautilities.command.CommandEvent;
+import com.jagrosh.jdautilities.command.SlashCommand;
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.Permission;
+import net.dv8tion.jda.api.entities.MessageEmbed;
+import net.dv8tion.jda.api.events.interaction.SlashCommandEvent;
+import net.dv8tion.jda.api.interactions.commands.OptionMapping;
+import net.dv8tion.jda.api.interactions.commands.OptionType;
+import net.dv8tion.jda.api.interactions.commands.build.OptionData;
+import pw.chew.chewbotcca.util.ResponseHelper;
 
 import java.text.NumberFormat;
+import java.util.Arrays;
 import java.util.Locale;
 import java.util.concurrent.ThreadLocalRandom;
 
 // %^roll command
-public class RollCommand extends Command {
+public class RollCommand extends SlashCommand {
     public RollCommand() {
         this.name = "roll";
         this.guildOnly = false;
+        this.help = "Rolls an optionally specified amount of dice";
         this.botPermissions = new Permission[]{Permission.MESSAGE_EMBED_LINKS};
+
+        this.options = Arrays.asList(
+            new OptionData(OptionType.INTEGER, "dice", "The amount of dice to throw. Default 1"),
+            new OptionData(OptionType.INTEGER, "sides", "The amount of sides on a die. Default 6.")
+        );
+    }
+
+    @Override
+    protected void execute(SlashCommandEvent slashCommandEvent) {
+        int dice = 1;
+        int sides = 6;
+        for (OptionMapping mapping : slashCommandEvent.getOptions()) {
+            switch (mapping.getName()) {
+                case "dice":
+                    dice = (int) mapping.getAsLong();
+                case "sides":
+                    sides = (int) mapping.getAsLong();
+            }
+        }
+
+        try {
+            slashCommandEvent.replyEmbeds(generateEmbed(dice, sides)).queue();
+        } catch (IllegalArgumentException e) {
+            slashCommandEvent.replyEmbeds(ResponseHelper.generateFailureEmbed(null, e.getMessage()))
+                .setEphemeral(true)
+                .queue();
+        }
     }
 
     @Override
     protected void execute(CommandEvent commandEvent) {
+        commandEvent.getChannel().sendTyping().queue();
         // Get the args, if there's no args, just use a default 1d6
         String args = commandEvent.getArgs();
         if(args.isBlank()) {
@@ -56,24 +92,30 @@ public class RollCommand extends Command {
             commandEvent.reply("Your input is too big! Try again, but with lower numbers.");
             return;
         }
+
+        try {
+            commandEvent.reply(generateEmbed(dice, sides));
+        } catch (IllegalArgumentException e) {
+            commandEvent.reply(e.getMessage());
+        }
+    }
+
+    private MessageEmbed generateEmbed(int dice, int sides) {
         // If the args are invalid, let them know
         if(dice < 1) {
-            commandEvent.reply("You must roll at least 1 die.");
-            return;
+            throw new IllegalArgumentException("You must roll at least 1 die.");
         }
         if(sides < 1) {
-            commandEvent.reply("Sides cannot be less than 1!");
-            return;
+            throw new IllegalArgumentException("Sides cannot be less than 1!");
         }
         // Do the math to calculate the dice roll
-        commandEvent.getChannel().sendTyping().queue();
         long total = 0;
         for(int i = 0; i < dice; i++) {
             total += ThreadLocalRandom.current().nextInt(0, sides) + 1;
         }
 
         // Take the data, make an embed, and send it off
-        commandEvent.reply(new EmbedBuilder()
+        return (new EmbedBuilder()
                 .setTitle("Dice Roll \uD83C\uDFB2")
                 .addField("Dice", NumberFormat.getNumberInstance(Locale.US).format(dice), true)
                 .addField("Sides", NumberFormat.getNumberInstance(Locale.US).format(sides), true)

--- a/src/main/java/pw/chew/chewbotcca/commands/fun/SpigotDramaCommand.java
+++ b/src/main/java/pw/chew/chewbotcca/commands/fun/SpigotDramaCommand.java
@@ -16,23 +16,35 @@
  */
 package pw.chew.chewbotcca.commands.fun;
 
-import com.jagrosh.jdautilities.command.Command;
 import com.jagrosh.jdautilities.command.CommandEvent;
+import com.jagrosh.jdautilities.command.SlashCommand;
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.Permission;
+import net.dv8tion.jda.api.entities.MessageEmbed;
+import net.dv8tion.jda.api.events.interaction.SlashCommandEvent;
 import pro.chew.api.objects.SpigotDrama;
 import pw.chew.chewbotcca.objects.Memory;
 
 // %^spigotdrama command
-public class SpigotDramaCommand extends Command {
+public class SpigotDramaCommand extends SlashCommand {
     public SpigotDramaCommand() {
         this.name = "spigotdrama";
         this.guildOnly = false;
+        this.help = "Generates some random Spigot drama";
         this.botPermissions = new Permission[]{Permission.MESSAGE_EMBED_LINKS};
     }
 
     @Override
+    protected void execute(SlashCommandEvent slashCommandEvent) {
+        slashCommandEvent.replyEmbeds(generateDramaEmbed()).queue();
+    }
+
+    @Override
     protected void execute(CommandEvent commandEvent) {
+        commandEvent.reply(generateDramaEmbed());
+    }
+
+    private MessageEmbed generateDramaEmbed() {
         // Get a SpigotDrama response
         SpigotDrama response = Memory.getChewAPI().generateSpigotDrama();
         // Make an embed and send it off
@@ -41,6 +53,6 @@ public class SpigotDramaCommand extends Command {
         embed.setTitle("Spigot Drama Generator", "https://drama.essentialsx.net/");
         embed.setDescription(response.getPhrase() + "\n\n" + "[Permalink](" + response.getPermalink() + ")");
 
-        commandEvent.reply(embed.build());
+        return embed.build();
     }
 }

--- a/src/main/java/pw/chew/chewbotcca/commands/fun/TRBMBCommand.java
+++ b/src/main/java/pw/chew/chewbotcca/commands/fun/TRBMBCommand.java
@@ -16,16 +16,23 @@
  */
 package pw.chew.chewbotcca.commands.fun;
 
-import com.jagrosh.jdautilities.command.Command;
 import com.jagrosh.jdautilities.command.CommandEvent;
+import com.jagrosh.jdautilities.command.SlashCommand;
+import net.dv8tion.jda.api.events.interaction.SlashCommandEvent;
 import pw.chew.chewbotcca.objects.Memory;
 
 // %^trbmb command
-public class TRBMBCommand extends Command {
+public class TRBMBCommand extends SlashCommand {
 
     public TRBMBCommand() {
         this.name = "trbmb";
+        this.help = "Generates a random TRBMB phrase";
         this.guildOnly = false;
+    }
+
+    @Override
+    protected void execute(SlashCommandEvent event) {
+        event.reply(Memory.getChewAPI().getTRBMBPhrase()).queue();
     }
 
     @Override

--- a/src/main/java/pw/chew/chewbotcca/commands/info/BotInfoCommand.java
+++ b/src/main/java/pw/chew/chewbotcca/commands/info/BotInfoCommand.java
@@ -16,11 +16,16 @@
  */
 package pw.chew.chewbotcca.commands.info;
 
-import com.jagrosh.jdautilities.command.Command;
 import com.jagrosh.jdautilities.command.CommandEvent;
+import com.jagrosh.jdautilities.command.SlashCommand;
 import net.dv8tion.jda.api.EmbedBuilder;
+import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.Permission;
 import net.dv8tion.jda.api.entities.User;
+import net.dv8tion.jda.api.events.interaction.SlashCommandEvent;
+import net.dv8tion.jda.api.interactions.commands.Command;
+import net.dv8tion.jda.api.interactions.commands.OptionType;
+import net.dv8tion.jda.api.interactions.commands.build.OptionData;
 import org.json.JSONObject;
 import pw.chew.chewbotcca.util.PropertiesManager;
 import pw.chew.chewbotcca.util.RestClient;
@@ -29,15 +34,38 @@ import java.awt.Color;
 import java.time.OffsetDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 // %^binfo command
-public class BotInfoCommand extends Command {
+public class BotInfoCommand extends SlashCommand {
     public BotInfoCommand() {
         this.name = "botinfo";
+        this.help = "Finds info on a specified bot";
         this.botPermissions = new Permission[]{Permission.MESSAGE_EMBED_LINKS};
         this.aliases = new String[]{"binfo"};
         this.guildOnly = false;
+        this.options = Arrays.asList(
+            new OptionData(OptionType.USER, "bot", "The bot to look up").setRequired(true),
+            new OptionData(OptionType.STRING, "list", "The list to look for, default: discord.bots.gg")
+                .addChoices(
+                    new Command.Choice("discord.bots.gg", "dbots"),
+                    new Command.Choice("top.gg", "topgg"),
+                    new Command.Choice("discordextremelist.xyz", "del")
+                )
+        );
+    }
+
+    @Override
+    protected void execute(SlashCommandEvent event) {
+        String botId = event.getOption("bot").getAsUser().getId();
+
+        // Get it from the specified list if it's valid, and let them know
+        switch (event.getOption("list").getAsString()) {
+            case "topgg" -> event.replyEmbeds(gatherTopggInfo(botId, event.getJDA()).build()).queue();
+            case "del" -> event.replyEmbeds(gatherDELInfo(botId, event.getJDA()).build()).queue();
+            default -> event.replyEmbeds(gatherDBotsInfo(botId, event.getJDA()).build()).queue();
+        }
     }
 
     @Override
@@ -64,9 +92,9 @@ public class BotInfoCommand extends Command {
         }
         // Get it from the specified list if it's valid, and let them know
         switch (list) {
-            case "dbl", "top.gg", "topgg" -> commandEvent.reply(gatherTopggInfo(botId, commandEvent).build());
-            case "dbots" -> commandEvent.reply(gatherDBotsInfo(botId, commandEvent).build());
-            case "del" -> commandEvent.reply(gatherDELInfo(botId, commandEvent).build());
+            case "dbl", "top.gg", "topgg" -> commandEvent.reply(gatherTopggInfo(botId, commandEvent.getJDA()).build());
+            case "dbots" -> commandEvent.reply(gatherDBotsInfo(botId, commandEvent.getJDA()).build());
+            case "del" -> commandEvent.reply(gatherDELInfo(botId, commandEvent.getJDA()).build());
             default -> commandEvent.reply("""
                 Invalid Bot List! Supported lists:
                 `dbots` -> <https://discord.bots.gg>
@@ -80,10 +108,10 @@ public class BotInfoCommand extends Command {
     /**
      * Gather info from top.gg
      * @param id the bot id
-     * @param event the command event
+     * @param jda JDA for user lookup
      * @return an embed ready to be build
      */
-    private EmbedBuilder gatherTopggInfo(String id, CommandEvent event) {
+    private EmbedBuilder gatherTopggInfo(String id, JDA jda) {
         // Get data from top.gg
         JSONObject bot = new JSONObject(RestClient.get("https://top.gg/api/bots/" + id, PropertiesManager.getTopggToken()));
 
@@ -142,7 +170,7 @@ public class BotInfoCommand extends Command {
         // Find and set owners
         List<String> owners = new ArrayList<>();
         for(Object owner : bot.getJSONArray("owners")) {
-            User user = event.getJDA().getUserById((String) owner);
+            User user = jda.getUserById((String) owner);
             if(user == null)
                 owners.add((String) owner);
             else
@@ -181,10 +209,10 @@ public class BotInfoCommand extends Command {
     /**
      * Gather info from (the superior) discord.bots.gg
      * @param id the bot id
-     * @param event the command event
+     * @param jda JDA for user lookup
      * @return an embed ready to be build
      */
-    private EmbedBuilder gatherDBotsInfo(String id, CommandEvent event) {
+    private EmbedBuilder gatherDBotsInfo(String id, JDA jda) {
         // Gather info from the site
         JSONObject bot = new JSONObject(RestClient.get("https://discord.bots.gg/api/v1/bots/" + id, PropertiesManager.getDbotsToken()));
 
@@ -205,7 +233,7 @@ public class BotInfoCommand extends Command {
         e.addField("Library", bot.getString("libraryName"), true);
 
         // Find and set the owner as a Discord User
-        User user = event.getJDA().getUserById(bot.getJSONObject("owner").getString("userId"));
+        User user = jda.getUserById(bot.getJSONObject("owner").getString("userId"));
         if(user == null)
             e.addField("Owner", "Unknown", true);
         else
@@ -236,10 +264,10 @@ public class BotInfoCommand extends Command {
     /**
      * Gathers bot info from DiscordExtremeList
      * @param id bot ID
-     * @param event the command event
+     * @param jda JDA for user lookup
      * @return an embed
      */
-    public EmbedBuilder gatherDELInfo(String id, CommandEvent event) {
+    public EmbedBuilder gatherDELInfo(String id, JDA jda) {
         // Gather info from the site
         JSONObject response = new JSONObject(RestClient.get("https://api.discordextremelist.xyz/v2/bot/" + id, PropertiesManager.getDELToken()));
 
@@ -291,7 +319,7 @@ public class BotInfoCommand extends Command {
         List<String> owners = new ArrayList<>();
         owners.add(bot.getJSONObject("owner").getString("id"));
         for(Object owner : bot.getJSONArray("editors")) {
-            User user = event.getJDA().getUserById((String) owner);
+            User user = jda.getUserById((String) owner);
             if(user == null)
                 owners.add((String) owner);
             else

--- a/src/main/java/pw/chew/chewbotcca/commands/info/BotInfoCommand.java
+++ b/src/main/java/pw/chew/chewbotcca/commands/info/BotInfoCommand.java
@@ -28,6 +28,7 @@ import net.dv8tion.jda.api.interactions.commands.OptionType;
 import net.dv8tion.jda.api.interactions.commands.build.OptionData;
 import org.json.JSONObject;
 import pw.chew.chewbotcca.util.PropertiesManager;
+import pw.chew.chewbotcca.util.ResponseHelper;
 import pw.chew.chewbotcca.util.RestClient;
 
 import java.awt.Color;
@@ -61,7 +62,7 @@ public class BotInfoCommand extends SlashCommand {
         String botId = event.getOption("bot").getAsUser().getId();
 
         // Get it from the specified list if it's valid, and let them know
-        switch (event.getOption("list").getAsString()) {
+        switch (ResponseHelper.guaranteeStringOption(event, "list", "dbots")) {
             case "topgg" -> event.replyEmbeds(gatherTopggInfo(botId, event.getJDA()).build()).queue();
             case "del" -> event.replyEmbeds(gatherDELInfo(botId, event.getJDA()).build()).queue();
             default -> event.replyEmbeds(gatherDBotsInfo(botId, event.getJDA()).build()).queue();

--- a/src/main/java/pw/chew/chewbotcca/commands/info/ChannelInfoCommand.java
+++ b/src/main/java/pw/chew/chewbotcca/commands/info/ChannelInfoCommand.java
@@ -31,6 +31,7 @@ import net.dv8tion.jda.api.events.interaction.SlashCommandEvent;
 import net.dv8tion.jda.api.interactions.commands.Command;
 import net.dv8tion.jda.api.interactions.commands.OptionType;
 import net.dv8tion.jda.api.interactions.commands.build.OptionData;
+import pw.chew.chewbotcca.util.ResponseHelper;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -64,7 +65,7 @@ public class ChannelInfoCommand extends SlashCommand {
     @Override
     protected void execute(SlashCommandEvent event) {
         GuildChannel channel = event.getOption("channel").getAsGuildChannel();
-        switch (event.getOption("type").getAsString()) {
+        switch (ResponseHelper.guaranteeStringOption(event, "type", "general")) {
             case "pins" -> getPinsInfo((TextChannel) channel, event.getJDA());
             default -> gatherMainInfo(channel, null);
         }

--- a/src/main/java/pw/chew/chewbotcca/commands/info/ChannelInfoCommand.java
+++ b/src/main/java/pw/chew/chewbotcca/commands/info/ChannelInfoCommand.java
@@ -65,10 +65,10 @@ public class ChannelInfoCommand extends SlashCommand {
     @Override
     protected void execute(SlashCommandEvent event) {
         GuildChannel channel = event.getOption("channel").getAsGuildChannel();
-        switch (ResponseHelper.guaranteeStringOption(event, "type", "general")) {
-            case "pins" -> getPinsInfo((TextChannel) channel, event.getJDA());
-            default -> gatherMainInfo(channel, null);
-        }
+        event.replyEmbeds(switch (ResponseHelper.guaranteeStringOption(event, "type", "general")) {
+            case "pins" -> getPinsInfo((TextChannel) channel, event.getJDA()).build();
+            default -> gatherMainInfo(channel, null).build();
+        }).queue();
     }
 
     @Override
@@ -149,7 +149,9 @@ public class ChannelInfoCommand extends SlashCommand {
                 List<Webhook> hooks = textChannel.retrieveWebhooks().complete();
                 e.addField("Webhooks", String.valueOf(hooks.size()), true);
             }
-            e.addField("Pins", textChannel.retrievePinnedMessages().complete().size() + " / 50", true);
+            if (commandEvent != null && commandEvent.getSelfMember().hasPermission(Permission.VIEW_CHANNEL)) {
+                e.addField("Pins", textChannel.retrievePinnedMessages().complete().size() + " / 50", true);
+            }
             List<String> info = new ArrayList<>();
             if (textChannel.isNews())
                 info.add("<:news:725504846937063595> News");

--- a/src/main/java/pw/chew/chewbotcca/commands/info/DiscrimCommand.java
+++ b/src/main/java/pw/chew/chewbotcca/commands/info/DiscrimCommand.java
@@ -37,6 +37,7 @@ public class DiscrimCommand extends Command {
 
     public DiscrimCommand() {
         this.name = "discrim";
+        this.help = "Find users with the same discriminator as you, or specify one";
         this.botPermissions = new Permission[]{Permission.MESSAGE_ADD_REACTION, Permission.MESSAGE_EMBED_LINKS};
         this.guildOnly = false;
     }

--- a/src/main/java/pw/chew/chewbotcca/commands/info/DiscrimCommand.java
+++ b/src/main/java/pw/chew/chewbotcca/commands/info/DiscrimCommand.java
@@ -131,6 +131,10 @@ public class DiscrimCommand extends SlashCommand {
         @Override
         protected void execute(SlashCommandEvent event) {
             String discrim = ResponseHelper.guaranteeStringOption(event, "discriminator", event.getUser().getDiscriminator());
+            if (!(discrim.length() == 4 && discrim.matches("[0-9]{4}"))) {
+                event.reply("Invalid discriminator provided!").setEphemeral(true).queue();
+                return;
+            }
             // Send message then edit it
             event.replyEmbeds(new EmbedBuilder().setDescription("Checking...").build()).queue(interactionHook -> {
                 interactionHook.retrieveOriginal().queue(message -> {

--- a/src/main/java/pw/chew/chewbotcca/commands/info/DiscrimCommand.java
+++ b/src/main/java/pw/chew/chewbotcca/commands/info/DiscrimCommand.java
@@ -16,14 +16,19 @@
  */
 package pw.chew.chewbotcca.commands.info;
 
-import com.jagrosh.jdautilities.command.Command;
 import com.jagrosh.jdautilities.command.CommandEvent;
+import com.jagrosh.jdautilities.command.SlashCommand;
 import com.jagrosh.jdautilities.menu.Paginator;
+import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.Permission;
 import net.dv8tion.jda.api.entities.User;
+import net.dv8tion.jda.api.events.interaction.SlashCommandEvent;
+import net.dv8tion.jda.api.interactions.commands.OptionType;
+import net.dv8tion.jda.api.interactions.commands.build.OptionData;
 import net.dv8tion.jda.api.utils.cache.SnowflakeCacheView;
 import pw.chew.chewbotcca.util.JDAUtilUtil;
+import pw.chew.chewbotcca.util.ResponseHelper;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -33,13 +38,22 @@ import java.util.List;
 import java.util.Map;
 
 // %^discrim command
-public class DiscrimCommand extends Command {
+public class DiscrimCommand extends SlashCommand {
 
     public DiscrimCommand() {
         this.name = "discrim";
         this.help = "Find users with the same discriminator as you, or specify one";
         this.botPermissions = new Permission[]{Permission.MESSAGE_ADD_REACTION, Permission.MESSAGE_EMBED_LINKS};
         this.guildOnly = false;
+        this.children = new SlashCommand[]{
+            new DiscrimListSubCommand(),
+            new DiscrimRankSubCommand()
+        };
+    }
+
+    @Override
+    protected void execute(SlashCommandEvent event) {
+        // SlashCommands with children don't have root command
     }
 
     @Override
@@ -49,15 +63,7 @@ public class DiscrimCommand extends Command {
         if (event.getArgs().length() == 4 && event.getArgs().matches("[0-9]{4}")) {
             discrim = event.getArgs();
         } else if (event.getArgs().contains("--rank")) {
-            Map<String, Integer> ranking = getDiscrimRanking(event.getJDA().getUserCache());
-            Map<String, Integer> ranked = sortByValue(ranking);
-            Paginator.Builder pbuilder = JDAUtilUtil.makePaginator();
-            pbuilder.setText("Users discriminator ranking"
-                + "\nCached users: " + event.getJDA().getUserCache().size());
-            for (String discriminator : ranked.keySet()) {
-                pbuilder.addItems("#" + discriminator + " - " + ranked.get(discriminator) + " users");
-            }
-            pbuilder.build().paginate(event.getChannel(), 1);
+            buildRankPaginator(event.getJDA()).paginate(event.getChannel(), 1);
             return;
         }
         Paginator p = buildDiscrimPaginator(discrim, event.getJDA());
@@ -74,6 +80,18 @@ public class DiscrimCommand extends Command {
             }
         }
 
+        return pbuilder.build();
+    }
+
+    public Paginator buildRankPaginator(JDA jda) {
+        Map<String, Integer> ranking = getDiscrimRanking(jda.getUserCache());
+        Map<String, Integer> ranked = sortByValue(ranking);
+        Paginator.Builder pbuilder = JDAUtilUtil.makePaginator();
+        pbuilder.setText("Users discriminator ranking"
+            + "\nCached users: " + jda.getUserCache().size());
+        for (String discriminator : ranked.keySet()) {
+            pbuilder.addItems("#" + discriminator + " - " + ranked.get(discriminator) + " users");
+        }
         return pbuilder.build();
     }
 
@@ -96,5 +114,49 @@ public class DiscrimCommand extends Command {
         }
 
         return result;
+    }
+
+    public class DiscrimListSubCommand extends SlashCommand {
+
+        public DiscrimListSubCommand() {
+            this.name = "list";
+            this.help = "List users with a given discriminator, or blank for your own";
+            this.botPermissions = new Permission[]{Permission.MESSAGE_ADD_REACTION, Permission.MESSAGE_EMBED_LINKS};
+            this.guildOnly = false;
+            this.options = Collections.singletonList(
+                new OptionData(OptionType.STRING, "discriminator", "The discriminator you want to lookup, or blank for yours")
+            );
+        }
+
+        @Override
+        protected void execute(SlashCommandEvent event) {
+            String discrim = ResponseHelper.guaranteeStringOption(event, "discriminator", event.getUser().getDiscriminator());
+            // Send message then edit it
+            event.replyEmbeds(new EmbedBuilder().setDescription("Checking...").build()).queue(interactionHook -> {
+                interactionHook.retrieveOriginal().queue(message -> {
+                    buildDiscrimPaginator(discrim, event.getJDA()).paginate(message, 1);
+                });
+            });
+        }
+    }
+
+    public class DiscrimRankSubCommand extends SlashCommand {
+
+        public DiscrimRankSubCommand() {
+            this.name = "rank";
+            this.help = "View most used discriminators, based on users in this bot's servers";
+            this.botPermissions = new Permission[]{Permission.MESSAGE_ADD_REACTION, Permission.MESSAGE_EMBED_LINKS};
+            this.guildOnly = false;
+        }
+
+        @Override
+        protected void execute(SlashCommandEvent event) {
+            // Send message then edit it
+            event.replyEmbeds(new EmbedBuilder().setDescription("Checking...").build()).queue(interactionHook -> {
+                interactionHook.retrieveOriginal().queue(message -> {
+                    buildRankPaginator(event.getJDA()).paginate(message, 1);
+                });
+            });
+        }
     }
 }

--- a/src/main/java/pw/chew/chewbotcca/commands/info/InfoCommand.java
+++ b/src/main/java/pw/chew/chewbotcca/commands/info/InfoCommand.java
@@ -46,7 +46,7 @@ public class InfoCommand extends SlashCommand {
 
         this.options = Collections.singletonList(
             new OptionData(OptionType.STRING, "command", "The command to find info for").setRequired(true)
-                .addChoices(commands())
+                //.addChoices(commands())
         );
     }
 

--- a/src/main/java/pw/chew/chewbotcca/commands/info/InfoCommand.java
+++ b/src/main/java/pw/chew/chewbotcca/commands/info/InfoCommand.java
@@ -16,23 +16,37 @@
  */
 package pw.chew.chewbotcca.commands.info;
 
-import com.jagrosh.jdautilities.command.Command;
 import com.jagrosh.jdautilities.command.CommandEvent;
+import com.jagrosh.jdautilities.command.SlashCommand;
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.Permission;
+import net.dv8tion.jda.api.events.interaction.SlashCommandEvent;
+import net.dv8tion.jda.api.interactions.commands.OptionType;
+import net.dv8tion.jda.api.interactions.commands.build.OptionData;
 import org.json.JSONArray;
 import org.json.JSONObject;
 import pw.chew.chewbotcca.util.PropertiesManager;
 import pw.chew.chewbotcca.util.RestClient;
 
 import java.util.ArrayList;
+import java.util.Collections;
 
 // %^info command
-public class InfoCommand extends Command {
+public class InfoCommand extends SlashCommand {
     public InfoCommand() {
         this.name = "info";
         this.botPermissions = new Permission[]{Permission.MESSAGE_EMBED_LINKS};
         this.guildOnly = false;
+
+        this.options = Collections.singletonList(
+            new OptionData(OptionType.STRING, "command", "The command to find info for").setRequired(true)
+                .addChoices()
+        );
+    }
+
+    @Override
+    protected void execute(SlashCommandEvent event) {
+
     }
 
     @Override

--- a/src/main/java/pw/chew/chewbotcca/commands/info/InfoCommand.java
+++ b/src/main/java/pw/chew/chewbotcca/commands/info/InfoCommand.java
@@ -20,16 +20,21 @@ import com.jagrosh.jdautilities.command.CommandEvent;
 import com.jagrosh.jdautilities.command.SlashCommand;
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.Permission;
+import net.dv8tion.jda.api.entities.MessageEmbed;
 import net.dv8tion.jda.api.events.interaction.SlashCommandEvent;
+import net.dv8tion.jda.api.interactions.commands.Command;
 import net.dv8tion.jda.api.interactions.commands.OptionType;
 import net.dv8tion.jda.api.interactions.commands.build.OptionData;
 import org.json.JSONArray;
 import org.json.JSONObject;
+import pw.chew.chewbotcca.objects.Memory;
 import pw.chew.chewbotcca.util.PropertiesManager;
+import pw.chew.chewbotcca.util.ResponseHelper;
 import pw.chew.chewbotcca.util.RestClient;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
 
 // %^info command
 public class InfoCommand extends SlashCommand {
@@ -41,13 +46,17 @@ public class InfoCommand extends SlashCommand {
 
         this.options = Collections.singletonList(
             new OptionData(OptionType.STRING, "command", "The command to find info for").setRequired(true)
-                .addChoices()
+                .addChoices(commands())
         );
     }
 
     @Override
     protected void execute(SlashCommandEvent event) {
-
+        try {
+            event.replyEmbeds(gatherData(ResponseHelper.guaranteeStringOption(event, "command", ""))).queue();
+        } catch (IllegalArgumentException e) {
+            event.replyEmbeds(ResponseHelper.generateFailureEmbed(null, e.getMessage())).setEphemeral(true).queue();
+        }
     }
 
     @Override
@@ -58,6 +67,15 @@ public class InfoCommand extends SlashCommand {
             event.reply("Please specify a command to find info for!");
             return;
         }
+
+        try {
+            event.reply(gatherData(command));
+        } catch (IllegalArgumentException e) {
+            event.replyWarning(e.getMessage());
+        }
+    }
+
+    private MessageEmbed gatherData(String command) {
         // Get the command from the chew api
         JSONObject data = new JSONObject(RestClient.get("https://chew.pw/chewbotcca/discord/api/command/" + command));
         // If there's an error
@@ -68,11 +86,10 @@ public class InfoCommand extends SlashCommand {
                 predictions.add(didYouMean.getString(i));
             }
             if (predictions.size() > 0) {
-                event.reply("Invalid command! See <https://chew.pw/chewbotcca/discord/commands> for a list of commands. Did you mean? " + String.join(", ", predictions));
+                throw new IllegalArgumentException("Invalid command! See <https://chew.pw/chewbotcca/discord/commands> for a list of commands. Did you mean? " + String.join(", ", predictions));
             } else {
-                event.reply("Invalid command! See <https://chew.pw/chewbotcca/discord/commands> for a list of commands.");
+                throw new IllegalArgumentException("Invalid command! See <https://chew.pw/chewbotcca/discord/commands> for a list of commands.");
             }
-            return;
         }
 
         // Gather the data and make an embed with it
@@ -86,7 +103,15 @@ public class InfoCommand extends SlashCommand {
         e.addField("Bot Permissions", data.isNull("bot_permissions") ? "*No special perms needed*" : data.getString("bot_permissions"), true);
         e.addField("User Permissions", data.isNull("user_permissions") ? "*No special perms needed*" : data.getString("user_permissions"), true);
 
-        event.reply(e.build());
+        return e.build();
+    }
+
+    private List<Command.Choice> commands() {
+        List<Command.Choice> response = new ArrayList<>();
+        for (com.jagrosh.jdautilities.command.Command command : Memory.getClient().getCommands()) {
+            response.add(new Command.Choice(command.getName(), command.getName()));
+        }
+        return response;
     }
 }
 

--- a/src/main/java/pw/chew/chewbotcca/commands/info/InfoCommand.java
+++ b/src/main/java/pw/chew/chewbotcca/commands/info/InfoCommand.java
@@ -35,6 +35,7 @@ import java.util.Collections;
 public class InfoCommand extends SlashCommand {
     public InfoCommand() {
         this.name = "info";
+        this.help = "Returns some detailed information about a specified command";
         this.botPermissions = new Permission[]{Permission.MESSAGE_EMBED_LINKS};
         this.guildOnly = false;
 

--- a/src/main/java/pw/chew/chewbotcca/commands/info/LastFMCommand.java
+++ b/src/main/java/pw/chew/chewbotcca/commands/info/LastFMCommand.java
@@ -34,6 +34,7 @@ public class LastFMCommand extends SlashCommand {
 
     public LastFMCommand() {
         this.name = "lastfm";
+        this.help = "Returns playing status for a specified user";
         this.botPermissions = new Permission[]{Permission.MESSAGE_EMBED_LINKS};
         this.guildOnly = false;
     }

--- a/src/main/java/pw/chew/chewbotcca/commands/info/LastFMCommand.java
+++ b/src/main/java/pw/chew/chewbotcca/commands/info/LastFMCommand.java
@@ -43,7 +43,7 @@ public class LastFMCommand extends SlashCommand {
         this.botPermissions = new Permission[]{Permission.MESSAGE_EMBED_LINKS};
         this.guildOnly = false;
         this.options = Collections.singletonList(
-            new OptionData(OptionType.STRING, "username", "The user to look up (default: yours if set)").setRequired(true)
+            new OptionData(OptionType.STRING, "username", "The user to look up (default: yours if set)")
         );
     }
 

--- a/src/main/java/pw/chew/chewbotcca/commands/info/LastFMCommand.java
+++ b/src/main/java/pw/chew/chewbotcca/commands/info/LastFMCommand.java
@@ -16,10 +16,11 @@
  */
 package pw.chew.chewbotcca.commands.info;
 
-import com.jagrosh.jdautilities.command.Command;
 import com.jagrosh.jdautilities.command.CommandEvent;
+import com.jagrosh.jdautilities.command.SlashCommand;
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.Permission;
+import net.dv8tion.jda.api.events.interaction.SlashCommandEvent;
 import org.json.JSONObject;
 import pw.chew.chewbotcca.objects.UserProfile;
 import pw.chew.chewbotcca.util.DateTime;
@@ -29,12 +30,17 @@ import pw.chew.chewbotcca.util.RestClient;
 import java.awt.Color;
 
 // %^lastfm command
-public class LastFMCommand extends Command {
+public class LastFMCommand extends SlashCommand {
 
     public LastFMCommand() {
         this.name = "lastfm";
         this.botPermissions = new Permission[]{Permission.MESSAGE_EMBED_LINKS};
         this.guildOnly = false;
+    }
+
+    @Override
+    protected void execute(SlashCommandEvent event) {
+
     }
 
     @Override

--- a/src/main/java/pw/chew/chewbotcca/commands/info/RoleInfoCommand.java
+++ b/src/main/java/pw/chew/chewbotcca/commands/info/RoleInfoCommand.java
@@ -46,6 +46,7 @@ public class RoleInfoCommand extends SlashCommand {
 
     public RoleInfoCommand() {
         this.name = "roleinfo";
+        this.help = "Find some information about roles";
         this.aliases = new String[]{"rinfo"};
         this.botPermissions = new Permission[]{Permission.MESSAGE_EMBED_LINKS, Permission.MESSAGE_ADD_REACTION};
         this.guildOnly = true;

--- a/src/main/java/pw/chew/chewbotcca/commands/info/RoleInfoCommand.java
+++ b/src/main/java/pw/chew/chewbotcca/commands/info/RoleInfoCommand.java
@@ -16,15 +16,21 @@
  */
 package pw.chew.chewbotcca.commands.info;
 
-import com.jagrosh.jdautilities.command.Command;
 import com.jagrosh.jdautilities.command.CommandEvent;
+import com.jagrosh.jdautilities.command.SlashCommand;
 import com.jagrosh.jdautilities.menu.Paginator;
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.Permission;
+import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.api.entities.Role;
+import net.dv8tion.jda.api.entities.User;
+import net.dv8tion.jda.api.events.interaction.SlashCommandEvent;
+import net.dv8tion.jda.api.interactions.commands.OptionType;
+import net.dv8tion.jda.api.interactions.commands.build.OptionData;
 import pw.chew.chewbotcca.util.JDAUtilUtil;
 import pw.chew.chewbotcca.util.Mention;
+import pw.chew.chewbotcca.util.ResponseHelper;
 
 import java.text.DecimalFormat;
 import java.text.NumberFormat;
@@ -34,18 +40,38 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Set;
 import java.util.TreeSet;
-import java.util.concurrent.TimeUnit;
-
-import static org.awaitility.Awaitility.await;
 
 // %^rinfo command
-public class RoleInfoCommand extends Command {
+public class RoleInfoCommand extends SlashCommand {
 
     public RoleInfoCommand() {
         this.name = "roleinfo";
         this.aliases = new String[]{"rinfo"};
         this.botPermissions = new Permission[]{Permission.MESSAGE_EMBED_LINKS, Permission.MESSAGE_ADD_REACTION};
         this.guildOnly = true;
+        this.options = Arrays.asList(
+            new OptionData(OptionType.ROLE, "role", "The role to get info about").setRequired(true),
+            new OptionData(OptionType.STRING, "mode", "The type of data to receive")
+                .addChoice("General Info", "general")
+                .addChoice("Members", "members")
+        );
+    }
+
+    @Override
+    protected void execute(SlashCommandEvent event) {
+        String mode = ResponseHelper.guaranteeStringOption(event, "mode", "general");
+
+        // "Nullable" begone
+        if (event.getGuild() == null || event.getMember() == null) return;
+
+        Role role = event.getOptionsByName("role").get(0).getAsRole();
+
+        // Make a response depending on the mode
+        if (mode.equals("members")) {
+            gatherMembersInfo(event.getGuild(), role, false, event.getUser());
+        } else {
+            event.replyEmbeds(gatherMainInfo(event.getGuild(), role, event.getMember()).build()).queue();
+        }
     }
 
     @Override
@@ -97,31 +123,28 @@ public class RoleInfoCommand extends Command {
 
         // Make a response depending on the mode
         if(mode.equals("members")) {
-            gatherMembersInfo(event, role, mention);
+            gatherMembersInfo(event.getGuild(), role, mention, event.getAuthor());
         } else {
-            event.reply(gatherMainInfo(event, role).build());
+            event.reply(gatherMainInfo(event.getGuild(), role, event.getMember()).build());
         }
     }
 
     /**
      * Gather main role info
-     * @param event the command event
-     * @param role the role
+     *
+     * @param server the server to get the role from
+     * @param role   the role
+     * @param author the author of the message for perm checks
      * @return an embed to be build
      */
-    public EmbedBuilder gatherMainInfo(CommandEvent event, Role role) {
+    public EmbedBuilder gatherMainInfo(Guild server, Role role, Member author) {
         EmbedBuilder embed = new EmbedBuilder();
         embed.setTitle("Role Information for: " + role.getName());
-        // Send typing, it'll be a while
-        event.getChannel().sendTyping().queue();
-        new Thread(() -> event.getGuild().loadMembers().get());
-        // I hate async, so this puts it back in sync
-        await().atMost(30, TimeUnit.SECONDS).until(() -> event.getGuild().getMemberCache().size() == event.getGuild().getMemberCount());
         // Get the member counts
-        int members = event.getGuild().getMembersWithRoles(role).size();
-        int total = event.getGuild().getMemberCount();
+        int members = server.getMembersWithRoles(role).size();
+        int total = server.getMemberCount();
         DecimalFormat df = new DecimalFormat("#.##");
-        String percent = df.format((float)members / (float)total * 100);
+        String percent = df.format((float) members / (float) total * 100);
         // Return the member count
         embed.addField("Members", NumberFormat.getNumberInstance(Locale.US).format(members) + " / " + NumberFormat.getNumberInstance(Locale.US).format(total) + " (" + percent + "%)", true);
         embed.addField("Mention / ID", role.getAsMention() + "\n" + role.getId(), true);
@@ -136,12 +159,12 @@ public class RoleInfoCommand extends Command {
         embed.setColor(role.getColor());
         embed.setFooter("Created");
         // If the user has permission to manage roles, show the permissions
-        if(event.getMember().hasPermission(Permission.MANAGE_ROLES)) {
+        if (author.hasPermission(Permission.MANAGE_ROLES)) {
             Permission[] perms = role.getPermissions().toArray(new Permission[0]);
             Set<Permission> temp = new TreeSet<>(Arrays.asList(perms));
             String description = "";
             if (!role.isPublicRole()) {
-                Permission[] every = event.getGuild().getPublicRole().getPermissions().toArray(new Permission[0]);
+                Permission[] every = server.getPublicRole().getPermissions().toArray(new Permission[0]);
                 Arrays.asList(every).forEach(temp::remove);
                 description = "Elevated permissions (perms this role has that everyone role doesn't)\n\n";
             }
@@ -154,25 +177,21 @@ public class RoleInfoCommand extends Command {
 
     /**
      * Gather members of a role
-     * @param event the command event
-     * @param role the role
+     *
+     * @param server  the server to get role from
+     * @param role    the role
      * @param mention should render mentions or not
      */
-    public void gatherMembersInfo(CommandEvent event, Role role, boolean mention) {
-        if(role == event.getGuild().getPublicRole()) {
-            event.reply("Finding all members is unsupported.");
-            return;
+    public Paginator gatherMembersInfo(Guild server, Role role, boolean mention, User author) {
+        if (role == server.getPublicRole()) {
+            throw new IllegalArgumentException("Finding all members is unsupported.");
         }
         Paginator.Builder paginator = JDAUtilUtil.makePaginator().clearItems();
         paginator.setText("Members in role " + role.getName());
-        // Get members
-        new Thread(() -> event.getGuild().loadMembers().get());
-        // Put response back in sync
-        await().atMost(30, TimeUnit.SECONDS).until(() -> event.getGuild().getMemberCache().size() == event.getGuild().getMemberCount());
         // Get the member list and find how members actually with the role
-        List<Member> memberList = event.getGuild().getMemberCache().asList();
-        for(Member member : memberList) {
-            if(member.getRoles().contains(role)) {
+        List<Member> memberList = server.getMemberCache().asList();
+        for (Member member : memberList) {
+            if (member.getRoles().contains(role)) {
                 if (mention)
                     paginator.addItems(member.getAsMention());
                 else
@@ -182,9 +201,7 @@ public class RoleInfoCommand extends Command {
         if (paginator.getItems().isEmpty())
             paginator.addItems("No one has this role!");
 
-        Paginator p = paginator.setUsers(event.getAuthor()).build();
-
-        p.paginate(event.getChannel(), 1);
+        return paginator.setUsers(author).build();
     }
 
     /**

--- a/src/main/java/pw/chew/chewbotcca/commands/info/RubyGemsCommand.java
+++ b/src/main/java/pw/chew/chewbotcca/commands/info/RubyGemsCommand.java
@@ -20,13 +20,18 @@ import com.jagrosh.jdautilities.command.CommandEvent;
 import com.jagrosh.jdautilities.command.SlashCommand;
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.Permission;
+import net.dv8tion.jda.api.entities.MessageEmbed;
 import net.dv8tion.jda.api.events.interaction.SlashCommandEvent;
+import net.dv8tion.jda.api.interactions.commands.OptionType;
+import net.dv8tion.jda.api.interactions.commands.build.OptionData;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
+import pw.chew.chewbotcca.util.ResponseHelper;
 import pw.chew.chewbotcca.util.RestClient;
 
 import java.text.NumberFormat;
+import java.util.Collections;
 import java.util.Locale;
 
 // %^rubygem command
@@ -38,45 +43,61 @@ public class RubyGemsCommand extends SlashCommand {
         this.aliases = new String[]{"gem", "rgem", "rubyg", "gems"};
         this.botPermissions = new Permission[]{Permission.MESSAGE_EMBED_LINKS};
         this.guildOnly = false;
+        this.options = Collections.singletonList(
+            new OptionData(OptionType.STRING, "gem", "The gem to lookup").setRequired(true)
+        );
     }
 
     @Override
     protected void execute(SlashCommandEvent event) {
-
+        try {
+            event.replyEmbeds(gatherGemData(ResponseHelper.guaranteeStringOption(event, "gem", ""))).queue();
+        } catch (IllegalArgumentException e) {
+            event.replyEmbeds(ResponseHelper.generateFailureEmbed(null, e.getMessage())).setEphemeral(true).queue();
+        }
     }
 
     @Override
     protected void execute(CommandEvent event) {
         // Start typing
         event.getChannel().sendTyping().queue();
+
+        try {
+            event.reply(gatherGemData(event.getArgs().trim()));
+        } catch (IllegalArgumentException e) {
+            event.replyWarning(e.getMessage());
+        }
+    }
+
+    private MessageEmbed gatherGemData(String name) {
         JSONObject data;
         // Get gem if it exists
         try {
-            data = new JSONObject(RestClient.get("https://rubygems.org/api/v1/gems/" + event.getArgs() + ".json"));
+            data = new JSONObject(RestClient.get("https://rubygems.org/api/v1/gems/" + name + ".json"));
         } catch (JSONException e) {
-            event.reply("Invalid ruby gem!");
-            return;
+            throw new IllegalArgumentException("Invalid ruby gem!");
         }
         // Get ranking from best gems
         int rank = -1;
         try {
-            rank = new JSONArray(RestClient.get("https://bestgems.org/api/v1/gems/" + event.getArgs() + "/total_ranking.json")).getJSONObject(0).getInt("total_ranking");
-        } catch (JSONException ignored) { }
+            rank = new JSONArray(RestClient.get("https://bestgems.org/api/v1/gems/" + name + "/total_ranking.json")).getJSONObject(0).getInt("total_ranking");
+        } catch (JSONException ignored) {
+        }
 
         // Get info
         EmbedBuilder e = new EmbedBuilder();
-                e.setTitle(data.getString("name") + " (" + data.getString("version") + ")", data.getString("project_uri"));
-                e.setAuthor("RubyGem Information", null, "https://cdn.discordapp.com/emojis/232899886419410945.png");
-                e.setDescription(data.getString("info"));
+        e.setTitle(data.getString("name") + " (" + data.getString("version") + ")", data.getString("project_uri"));
+        e.setAuthor("RubyGem Information", null, "https://cdn.discordapp.com/emojis/232899886419410945.png");
+        e.setDescription(data.getString("info"));
 
         e.addField("Authors", data.getString("authors"), true);
 
         e.addField("Downloads", "For Version: " + NumberFormat.getNumberInstance(Locale.US).format(data.getInt("version_downloads")) + "\n" +
-                "Total: " + NumberFormat.getNumberInstance(Locale.US).format(data.getInt("downloads")), true);
+            "Total: " + NumberFormat.getNumberInstance(Locale.US).format(data.getInt("downloads")), true);
 
         if (!data.isNull("licenses"))
             e.addField("License", data.getJSONArray("licenses").getString(0), true);
-        if(rank > -1)
+        if (rank > -1)
             e.addField("Rank", "#" + NumberFormat.getNumberInstance(Locale.US).format(rank), true);
         else
             e.addField("Rank", "Not Ranked Yet", true);
@@ -102,6 +123,6 @@ public class RubyGemsCommand extends SlashCommand {
 
         e.addField("Links", links.toString(), true);
 
-        event.reply(e.build());
+        return e.build();
     }
 }

--- a/src/main/java/pw/chew/chewbotcca/commands/info/RubyGemsCommand.java
+++ b/src/main/java/pw/chew/chewbotcca/commands/info/RubyGemsCommand.java
@@ -34,6 +34,7 @@ public class RubyGemsCommand extends SlashCommand {
 
     public RubyGemsCommand() {
         this.name = "rubygem";
+        this.help = "Searches for and returns some basic info about a specified ruby gem";
         this.aliases = new String[]{"gem", "rgem", "rubyg", "gems"};
         this.botPermissions = new Permission[]{Permission.MESSAGE_EMBED_LINKS};
         this.guildOnly = false;

--- a/src/main/java/pw/chew/chewbotcca/commands/info/RubyGemsCommand.java
+++ b/src/main/java/pw/chew/chewbotcca/commands/info/RubyGemsCommand.java
@@ -16,10 +16,11 @@
  */
 package pw.chew.chewbotcca.commands.info;
 
-import com.jagrosh.jdautilities.command.Command;
 import com.jagrosh.jdautilities.command.CommandEvent;
+import com.jagrosh.jdautilities.command.SlashCommand;
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.Permission;
+import net.dv8tion.jda.api.events.interaction.SlashCommandEvent;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -29,13 +30,18 @@ import java.text.NumberFormat;
 import java.util.Locale;
 
 // %^rubygem command
-public class RubyGemsCommand extends Command {
+public class RubyGemsCommand extends SlashCommand {
 
     public RubyGemsCommand() {
         this.name = "rubygem";
         this.aliases = new String[]{"gem", "rgem", "rubyg", "gems"};
         this.botPermissions = new Permission[]{Permission.MESSAGE_EMBED_LINKS};
         this.guildOnly = false;
+    }
+
+    @Override
+    protected void execute(SlashCommandEvent event) {
+
     }
 
     @Override

--- a/src/main/java/pw/chew/chewbotcca/commands/info/ServerInfoCommand.java
+++ b/src/main/java/pw/chew/chewbotcca/commands/info/ServerInfoCommand.java
@@ -326,7 +326,11 @@ public class ServerInfoCommand extends SlashCommand {
             boolean displayMode = ResponseHelper.guaranteeBooleanOption(event, "display_role", false);
             boolean onlineMode = ResponseHelper.guaranteeBooleanOption(event, "online", false);
 
-            run(guaranteeGuild(event), event.getTextChannel(), displayMode, onlineMode);
+            event.replyEmbeds(new EmbedBuilder().setDescription("Gathering the details...").build()).queue(interactionHook -> {
+                interactionHook.retrieveOriginal().queue(message -> {
+                    run(guaranteeGuild(event), event.getTextChannel(), displayMode, onlineMode);
+                });
+            });
         }
 
         @Override
@@ -436,7 +440,11 @@ public class ServerInfoCommand extends SlashCommand {
 
         @Override
         protected void execute(SlashCommandEvent event) {
-            run(guaranteeGuild(event), event.getUser(), event.getTextChannel(), event.getOption("render_mention").getAsBoolean());
+            event.replyEmbeds(new EmbedBuilder().setDescription("Gathering the details...").build()).queue(interactionHook -> {
+                interactionHook.retrieveOriginal().queue(message -> {
+                    run(guaranteeGuild(event), event.getUser(), event.getTextChannel(), ResponseHelper.guaranteeBooleanOption(event, "render_mention", false));
+                });
+            });
         }
 
         @Override

--- a/src/main/java/pw/chew/chewbotcca/commands/info/ServerInfoCommand.java
+++ b/src/main/java/pw/chew/chewbotcca/commands/info/ServerInfoCommand.java
@@ -16,8 +16,8 @@
  */
 package pw.chew.chewbotcca.commands.info;
 
-import com.jagrosh.jdautilities.command.Command;
 import com.jagrosh.jdautilities.command.CommandEvent;
+import com.jagrosh.jdautilities.command.SlashCommand;
 import com.jagrosh.jdautilities.menu.Paginator;
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.OnlineStatus;
@@ -26,9 +26,15 @@ import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.api.entities.Role;
 import net.dv8tion.jda.api.entities.TextChannel;
+import net.dv8tion.jda.api.entities.User;
 import net.dv8tion.jda.api.entities.VoiceChannel;
+import net.dv8tion.jda.api.events.interaction.SlashCommandEvent;
+import net.dv8tion.jda.api.interactions.commands.OptionType;
+import net.dv8tion.jda.api.interactions.commands.build.OptionData;
+import pw.chew.chewbotcca.objects.IKnowWhatIAmDoingISwearException;
 import pw.chew.chewbotcca.util.DateTime;
 import pw.chew.chewbotcca.util.JDAUtilUtil;
+import pw.chew.chewbotcca.util.ResponseHelper;
 
 import java.text.DecimalFormat;
 import java.text.NumberFormat;
@@ -42,18 +48,21 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 import java.util.TreeMap;
 import java.util.stream.Collectors;
 
 // %^sinfo command
-public class ServerInfoCommand extends Command {
+public class ServerInfoCommand extends SlashCommand {
 
     public ServerInfoCommand() {
         this.name = "serverinfo";
+        this.help = "Gathers general information about the server";
         this.aliases = new String[]{"sinfo"};
         this.botPermissions = new Permission[]{Permission.MESSAGE_EMBED_LINKS};
         this.guildOnly = true;
-        this.children = new Command[]{
+        this.children = new SlashCommand[]{
+            new ServerGeneralInfoSubCommand(),
             new ServerBoostsInfoSubCommand(),
             new ServerBotsSubCommand(),
             new ServerChannelsInfoSubCommand(),
@@ -65,10 +74,16 @@ public class ServerInfoCommand extends Command {
     }
 
     @Override
-    protected void execute(CommandEvent event) {
-        // Get args and the guild
-        Guild server = event.getGuild();
+    protected void execute(SlashCommandEvent event) {
+        event.replyEmbeds(gatherGeneralInfo(Objects.requireNonNull(event.getGuild())).build()).queue();
+    }
 
+    @Override
+    protected void execute(CommandEvent event) {
+        event.reply(gatherGeneralInfo(event.getGuild()).build());
+    }
+
+    private EmbedBuilder gatherGeneralInfo(Guild server) {
         EmbedBuilder e = new EmbedBuilder();
         e.setTitle("Server Information");
         if(server.getDescription() != null)
@@ -123,15 +138,15 @@ public class ServerInfoCommand extends Command {
         counts.add("Text: " + textchans);
         counts.add("Voice: " + voicechans);
         counts.add("Categories: " + categories);
-        if(server.getFeatures().contains("COMMERCE"))
+        if (server.getFeatures().contains("COMMERCE"))
             counts.add("Store Pages: " + storechans);
-        if(server.getFeatures().contains("NEWS"))
+        if (server.getFeatures().contains("NEWS"))
             counts.add("News: " + newschans);
 
         e.addField("Channel Count", String.join("\n", counts), true);
 
         // Server Boosting Stats
-        if(server.getBoostCount() > 0 && server.getBoostRole() != null) {
+        if (server.getBoostCount() > 0 && server.getBoostRole() != null) {
             e.addField("Server Boosting",
                 "Level: " + server.getBoostTier().getKey() +
                     "\nBoosts: " + server.getBoostCount() +
@@ -146,7 +161,7 @@ public class ServerInfoCommand extends Command {
         for (String perk : features) {
             perks.add(perkParser(perk, server));
         }
-        if(perks.size() > 0) {
+        if (perks.size() > 0) {
             e.addField("Features", String.join("\n", perks), true);
         }
 
@@ -157,20 +172,19 @@ public class ServerInfoCommand extends Command {
             Channels - `%^sinfo channels`
             Member Milestones - `%^sinfo milestones`
             Member Stats - `%^sinfo memberstats`
-            """.replaceAll("%\\^", event.getPrefix()), false);
+            """/*.replaceAll("%\\^", event.getPrefix())*/, false);
 
         e.setFooter("Server Created on");
         e.setTimestamp(server.getTimeCreated());
 
-        e.setColor(event.getSelfMember().getColor());
-
-        event.reply(e.build());
+        return e;
     }
 
     /**
      * Parse the perk list and make it fancy if necessary
+     *
      * @param feature the feature
-     * @param server the server
+     * @param server  the server
      * @return the perks as nice list
      */
     public String perkParser(String feature, Guild server) {
@@ -194,12 +208,12 @@ public class ServerInfoCommand extends Command {
         }
     }
 
-    /*
-    Source: https://github.com/ChewMC/TransmuteIt/blob/2b86/src/pw/chew/transmuteit/DiscoveriesCommand.java#L174-L186
-    Capitalizes a String, e.g. "BRUH_MOMENT" -> "Bruh Moment"
+    /**
+     * Source: https://github.com/ChewMC/TransmuteIt/blob/2b86/src/pw/chew/transmuteit/DiscoveriesCommand.java#L174-L186
+     * Capitalizes a String, e.g. "BRUH_MOMENT" -> "Bruh Moment"
      */
     public static String capitalize(String to) {
-        if(to.equals("")) {
+        if (to.equals("")) {
             return "";
         }
         String[] words = to.split("_");
@@ -213,67 +227,122 @@ public class ServerInfoCommand extends Command {
     }
 
     /**
+     * Helper method because it doesn't understand guildOnly really does mean guildOnly
+     *
+     * @param event the slash command event
+     * @return the NEVER NULL guild
+     */
+    private static Guild guaranteeGuild(SlashCommandEvent event) {
+        Guild server = event.getGuild();
+        if (server == null) {
+            throw new IKnowWhatIAmDoingISwearException();
+        }
+        return server;
+    }
+
+    /**
+     * Gathers general info about the server.
+     * Only required for slash command
+     */
+    private class ServerGeneralInfoSubCommand extends SlashCommand {
+
+        public ServerGeneralInfoSubCommand() {
+            this.name = "general";
+            this.help = "Gathers general information about this server";
+            this.guildOnly = true;
+        }
+
+        @Override
+        protected void execute(SlashCommandEvent event) {
+            event.replyEmbeds(gatherGeneralInfo(guaranteeGuild(event)).build()).queue();
+        }
+    }
+
+    /**
      * Gathers info about boosters and how long they've been boosting
      */
-    private static class ServerBoostsInfoSubCommand extends Command {
+    private static class ServerBoostsInfoSubCommand extends SlashCommand {
 
         public ServerBoostsInfoSubCommand() {
-            this.name = "boost";
-            this.aliases = new String[]{"boosts"};
+            this.name = "boosts";
+            this.help = "Gathers information about this server's boosts.";
+            this.aliases = new String[]{"boost"};
             this.guildOnly = true;
             this.botPermissions = new Permission[]{Permission.MESSAGE_EMBED_LINKS};
         }
 
         @Override
+        protected void execute(SlashCommandEvent event) {
+            event.replyEmbeds(gatherInfo(guaranteeGuild(event)).build()).queue();
+        }
+
+        @Override
         protected void execute(CommandEvent event) {
+            event.reply(gatherInfo(event.getGuild()).build());
+        }
+
+        private EmbedBuilder gatherInfo(Guild server) {
             // Get boosters
-            List<Member> boosters = event.getGuild().getBoosters();
+            List<Member> boosters = server.getBoosters();
             EmbedBuilder embed = new EmbedBuilder();
-            embed.setTitle("Boosters for " + event.getGuild().getName());
+            embed.setTitle("Boosters for " + server.getName());
             List<CharSequence> boostString = new ArrayList<>();
             // Get a now time for a basis of comparison
             Instant now = Instant.now();
             for (Member booster : boosters) {
                 OffsetDateTime timeBoosted = booster.getTimeBoosted();
                 // If they're still boosting (in case they stop boosting between gathering boosters and finding how long they're boosting
-                if(timeBoosted != null)
+                if (timeBoosted != null)
                     boostString.add(booster.getAsMention() + " for " + DateTime.timeAgo(now.toEpochMilli() - timeBoosted.toInstant().toEpochMilli()));
             }
             embed.setDescription(String.join("\n", boostString));
-            if(boostString.isEmpty()) {
+            if (boostString.isEmpty()) {
                 embed.setDescription("No one is boosting! Will you be the first?");
             }
-            event.reply(embed.build());
+
+            return embed;
         }
     }
 
     /**
      * Gather role information
      */
-    private static class ServerRolesInfoSubCommand extends Command {
+    private static class ServerRolesInfoSubCommand extends SlashCommand {
 
         public ServerRolesInfoSubCommand() {
             this.name = "roles";
+            this.help = "Gathers information about this server's roles.";
             this.guildOnly = true;
             this.botPermissions = new Permission[]{Permission.MESSAGE_EMBED_LINKS, Permission.MESSAGE_ADD_REACTION};
+
+            List<OptionData> data = new ArrayList<>();
+            data.add(new OptionData(OptionType.BOOLEAN, "display_role", "Show amount of members whose display role is this.").setRequired(false));
+            data.add(new OptionData(OptionType.BOOLEAN, "online", "Shows amount of members with this role currently online").setRequired(false));
+            this.options = data;
+        }
+
+        @Override
+        protected void execute(SlashCommandEvent event) {
+            boolean displayMode = ResponseHelper.guaranteeBooleanOption(event, "display_role", false);
+            boolean onlineMode = ResponseHelper.guaranteeBooleanOption(event, "online", false);
+
+            run(guaranteeGuild(event), event.getTextChannel(), displayMode, onlineMode);
         }
 
         @Override
         protected void execute(CommandEvent event) {
-            boolean displayMode = false;
-            boolean onlineMode = false;
-            if (event.getArgs().contains("--display")) {
-                displayMode = true;
-            }
-            if (event.getArgs().contains("--online")) {
-                onlineMode = true;
-            }
+            boolean displayMode = event.getArgs().contains("--display");
+            boolean onlineMode = event.getArgs().contains("--online");
 
+            run(event.getGuild(), event.getTextChannel(), displayMode, onlineMode);
+        }
+
+        public void run(Guild server, TextChannel channel, boolean displayMode, boolean onlineMode) {
             Paginator.Builder pbuilder = JDAUtilUtil.makePaginator().clearItems();
 
             List<CharSequence> roleNames = new ArrayList<>();
 
-            roleNames.add("Role List for " + event.getGuild().getName());
+            roleNames.add("Role List for " + server.getName());
             String format = "Format: %ONLINE%Total members with this role%DISPLAY% - Role Mention";
             if (onlineMode) {
                 format = format.replace("%ONLINE%", "Online Members / ");
@@ -289,7 +358,7 @@ public class ServerInfoCommand extends Command {
             roleNames.add("Note: Bot roles and everyone role are skipped!");
 
             // Gather roles and iterate over each to find stats
-            List<Role> roles = event.getGuild().getRoles();
+            List<Role> roles = server.getRoles();
             for (Role role : roles) {
                 // Skip if bot role
                 if (role.getTags().isBot())
@@ -298,7 +367,7 @@ public class ServerInfoCommand extends Command {
                 if (role.isPublicRole())
                     continue;
 
-                List<Member> membersWithRole = event.getGuild().getMembersWithRoles(role);
+                List<Member> membersWithRole = server.getMembersWithRoles(role);
                 if (membersWithRole.isEmpty()) {
                     pbuilder.addItems("0" + " - " + role.getAsMention());
                     continue;
@@ -344,31 +413,43 @@ public class ServerInfoCommand extends Command {
 
             Paginator p = pbuilder.setText(String.join("\n", roleNames)).build();
 
-            p.paginate(event.getChannel(), 1);
+            p.paginate(channel, 1);
         }
     }
 
     /**
      * Gather server bots
      */
-    private static class ServerBotsSubCommand extends Command {
+    private static class ServerBotsSubCommand extends SlashCommand {
 
         public ServerBotsSubCommand() {
             this.name = "bots";
+            this.help = "Gathers information about this server's bots.";
             this.aliases = new String[]{"bot"};
             this.botPermissions = new Permission[]{Permission.MESSAGE_EMBED_LINKS, Permission.MESSAGE_ADD_REACTION};
             this.guildOnly = true;
+
+            List<OptionData> data = new ArrayList<>();
+            data.add(new OptionData(OptionType.BOOLEAN, "render_mention", "Whether or not to render as a mention.").setRequired(true));
+            this.options = data;
+        }
+
+        @Override
+        protected void execute(SlashCommandEvent event) {
+            run(guaranteeGuild(event), event.getUser(), event.getTextChannel(), event.getOption("render_mention").getAsBoolean());
         }
 
         @Override
         protected void execute(CommandEvent event) {
-            boolean renderMention = event.getArgs().contains("--mention");
+            run(event.getGuild(), event.getAuthor(), event.getTextChannel(), event.getArgs().contains("--mention"));
+        }
 
+        private void run(Guild server, User author, TextChannel channel, boolean renderMention) {
             Paginator.Builder pbuilder = JDAUtilUtil.makePaginator().clearItems();
 
-            pbuilder.setText("Bots on " + event.getGuild().getName() + "\n" + "Newest bots on the bottom");
+            pbuilder.setText("Bots on " + server.getName() + "\n" + "Newest bots on the bottom");
             // Get all members as an array an sort it by join time
-            Member[] members = event.getGuild().getMembers().toArray(new Member[0]);
+            Member[] members = server.getMembers().toArray(new Member[0]);
             Arrays.sort(members, (o1, o2) -> {
                 if (o1.getTimeJoined().toEpochSecond() > o2.getTimeJoined().toEpochSecond())
                     return 1;
@@ -380,7 +461,7 @@ public class ServerInfoCommand extends Command {
             // Iterate over each bot to find how long they've been on
             for (Member member : members) {
                 if (member.getUser().isBot()) {
-                    if(renderMention) {
+                    if (renderMention) {
                         pbuilder.addItems(member.getAsMention() + " added " + DateTime.timeAgo(Instant.now().toEpochMilli() - member.getTimeJoined().toInstant().toEpochMilli(), false) + " ago");
                     } else {
                         pbuilder.addItems(member.getUser().getAsTag() + " added " + DateTime.timeAgo(Instant.now().toEpochMilli() - member.getTimeJoined().toInstant().toEpochMilli(), false) + " ago");
@@ -388,21 +469,38 @@ public class ServerInfoCommand extends Command {
                 }
             }
 
-            pbuilder.setUsers(event.getAuthor())
+            pbuilder.setUsers(author)
                 .build()
-                .paginate(event.getChannel(), 1);
+                .paginate(channel, 1);
         }
     }
 
     /**
      * Get a member by join position
      */
-    private static class ServerMemberByJoinSubCommand extends Command {
+    private static class ServerMemberByJoinSubCommand extends SlashCommand {
 
         public ServerMemberByJoinSubCommand() {
             this.name = "member";
+            this.help = "Search for a member by a join position.";
             this.botPermissions = new Permission[]{Permission.MESSAGE_EMBED_LINKS};
             this.guildOnly = true;
+
+            List<OptionData> data = new ArrayList<>();
+            data.add(new OptionData(OptionType.INTEGER, "position", "The join position to reverse-search the Member..").setRequired(true));
+            this.options = data;
+        }
+
+        @Override
+        protected void execute(SlashCommandEvent event) {
+            try {
+                event.replyEmbeds(new UserInfoCommand().gatherMemberInfo(guaranteeGuild(event), gatherMember(guaranteeGuild(event), (int) event.getOption("position").getAsLong())).build()).queue();
+            } catch (IllegalArgumentException e) {
+                event.replyEmbeds(new EmbedBuilder()
+                    .setTitle("Error occurred!")
+                    .setDescription(e.getMessage())
+                    .build()).queue();
+            }
         }
 
         @Override
@@ -415,12 +513,22 @@ public class ServerInfoCommand extends Command {
                 return;
             }
 
-            if (position > event.getGuild().getMemberCache().size() || position <= 0) {
-                event.reply(new EmbedBuilder().setTitle("Error occurred!").setDescription("Invalid input! Must be 1 <= x <=" + event.getGuild().getMemberCache().size()).build());
-                return;
+            try {
+                event.reply(new UserInfoCommand().gatherMemberInfo(event.getGuild(), gatherMember(event.getGuild(), position)).build());
+            } catch (IllegalArgumentException e) {
+                event.reply(new EmbedBuilder()
+                    .setTitle("Error occurred!")
+                    .setDescription(e.getMessage())
+                    .build());
+            }
+        }
+
+        public Member gatherMember(Guild server, int position) {
+            if (position > server.getMemberCache().size() || position <= 0) {
+                throw new IllegalArgumentException("Invalid input! Must be 1 <= x <=" + server.getMemberCache().size());
             }
 
-            List<Member> members = event.getGuild().getMemberCache().asList();
+            List<Member> members = server.getMemberCache().asList();
             Member[] bruh = members.toArray(new Member[0]);
             Arrays.sort(bruh, (o1, o2) -> {
                 if (o1.getTimeJoined().toEpochSecond() > o2.getTimeJoined().toEpochSecond())
@@ -430,25 +538,34 @@ public class ServerInfoCommand extends Command {
                 else
                     return -1;
             });
-            event.reply(new UserInfoCommand().gatherMemberInfo(event.getGuild(), bruh[position - 1]).build());
+            return bruh[position - 1];
         }
     }
 
     /**
      * Get channel info, like count and other info
      */
-    private static class ServerChannelsInfoSubCommand extends Command {
+    private static class ServerChannelsInfoSubCommand extends SlashCommand {
 
         public ServerChannelsInfoSubCommand() {
-            this.name = "channel";
-            this.aliases = new String[]{"channels"};
+            this.name = "channels";
+            this.help = "Gathers information about this server's channels.";
+            this.aliases = new String[]{"channel"};
             this.botPermissions = new Permission[]{Permission.MESSAGE_EMBED_LINKS};
             this.guildOnly = true;
         }
 
         @Override
+        protected void execute(SlashCommandEvent event) {
+            event.replyEmbeds(gatherChannelInfo(guaranteeGuild(event)).build()).queue();
+        }
+
+        @Override
         protected void execute(CommandEvent event) {
-            Guild server = event.getGuild();
+            event.reply(gatherChannelInfo(event.getGuild()).build());
+        }
+
+        private EmbedBuilder gatherChannelInfo(Guild server) {
             DecimalFormat df = new DecimalFormat("#.##");
 
             EmbedBuilder embed = new EmbedBuilder();
@@ -465,8 +582,8 @@ public class ServerInfoCommand extends Command {
             int nsfw = 0;
             int inVoice = 0;
 
-            for(TextChannel channel : server.getTextChannels()) {
-                if(channel.isNews()) {
+            for (TextChannel channel : server.getTextChannels()) {
+                if (channel.isNews()) {
                     newsChannels++;
                     textChannels--;
                 }
@@ -481,7 +598,7 @@ public class ServerInfoCommand extends Command {
 
             String percentText = df.format((float) textChannels / (float) totalChannels * 100);
             String percentVoice = df.format((float) voiceChannels / (float) totalChannels * 100);
-            String percentCategory = df.format((float)categories / (float) totalChannels * 100);
+            String percentCategory = df.format((float) categories / (float) totalChannels * 100);
             String percentStore = df.format((float) storeChannels / (float) totalChannels * 100);
             String percentNews = df.format((float) newsChannels / (float) totalChannels * 100);
             String percentNSFW = df.format((float) nsfw / (float) textChannels * 100);
@@ -506,7 +623,7 @@ public class ServerInfoCommand extends Command {
                 true
             );
 
-            if(server.getFeatures().contains("COMMERCE")) {
+            if (server.getFeatures().contains("COMMERCE")) {
                 embed.addField(
                     "Store",
                     "Total: " + storeChannels + " (" + percentStore + "%)",
@@ -514,7 +631,7 @@ public class ServerInfoCommand extends Command {
                 );
             }
 
-            if(server.getFeatures().contains("NEWS")) {
+            if (server.getFeatures().contains("NEWS")) {
                 embed.addField(
                     "Announcement Channels",
                     "Total: " + newsChannels + " (" + percentNews + "%)",
@@ -522,35 +639,43 @@ public class ServerInfoCommand extends Command {
                 );
             }
 
-            event.reply(embed.build());
+            return embed;
         }
     }
 
     /**
      * Get member milestone (estimated)
      */
-    private static class ServerMemberMilestoneSubCommand extends Command {
+    private static class ServerMemberMilestoneSubCommand extends SlashCommand {
         final static int[] milestones = new int[]{10, 25, 50, 100, 500, 1000, 5000, 7000, 10000, 20000, 50000, 100000, 200000, 300000, 400000, 500000, 1000000};
 
         public ServerMemberMilestoneSubCommand() {
-            this.name = "milestone";
-            this.aliases = new String[]{"milestones"};
+            this.name = "milestones";
+            this.help = "Gathers information about this server's member milestones.";
+            this.aliases = new String[]{"milestone"};
             this.botPermissions = new Permission[]{Permission.MESSAGE_EMBED_LINKS};
             this.guildOnly = true;
         }
 
         @Override
-        protected void execute(CommandEvent event) {
-            Guild server = event.getGuild();
+        protected void execute(SlashCommandEvent event) {
+            event.replyEmbeds(gatherMilestoneStats(guaranteeGuild(event)).build()).queue();
+        }
 
+        @Override
+        protected void execute(CommandEvent event) {
+            event.reply(gatherMilestoneStats(event.getGuild()).build());
+        }
+
+        private EmbedBuilder gatherMilestoneStats(Guild server) {
             EmbedBuilder embed = new EmbedBuilder();
 
             embed.setTitle("Upcoming Member Milestones for " + server.getName());
 
             int members = server.getMemberCount();
-            int days = Math.round((float)(Instant.now().toEpochMilli() - server.getTimeCreated().toInstant().toEpochMilli()) / 1000 / 60 / 60 / 24);
+            int days = Math.round((float) (Instant.now().toEpochMilli() - server.getTimeCreated().toInstant().toEpochMilli()) / 1000 / 60 / 60 / 24);
 
-            float membersPerDay = (float)members / (float)days;
+            float membersPerDay = (float) members / (float) days;
 
             List<String> daysToMilestone = new ArrayList<>();
 
@@ -566,8 +691,8 @@ public class ServerInfoCommand extends Command {
                 if (milestone < members)
                     continue;
 
-                float daysNeeded = ((float)milestone / membersPerDay);
-                Instant timeAtMilestone = server.getTimeCreated().toInstant().plusMillis((long)(daysNeeded * 24 * 60 * 60 * 1000));
+                float daysNeeded = ((float) milestone / membersPerDay);
+                Instant timeAtMilestone = server.getTimeCreated().toInstant().plusMillis((long) (daysNeeded * 24 * 60 * 60 * 1000));
                 OffsetDateTime date = timeAtMilestone.atOffset(server.getTimeCreated().getOffset());
                 String day = date.format(format);
                 int year = date.getYear();
@@ -579,21 +704,31 @@ public class ServerInfoCommand extends Command {
 
             embed.setDescription(String.join("\n", daysToMilestone));
 
-            event.reply(embed.build());
+            return embed;
         }
     }
 
-    private static class ServerMemberStatsSubCommand extends Command {
+    private static class ServerMemberStatsSubCommand extends SlashCommand {
 
         public ServerMemberStatsSubCommand() {
             this.name = "memberstats";
+            this.help = "Gathers general statistics about this server's member.";
             this.botPermissions = new Permission[]{Permission.MESSAGE_EMBED_LINKS};
             this.guildOnly = true;
         }
 
         @Override
+        protected void execute(SlashCommandEvent event) {
+            event.replyEmbeds(gatherMemberStats(guaranteeGuild(event)).build()).queue();
+        }
+
+        @Override
         protected void execute(CommandEvent event) {
-            List<Member> members = event.getGuild().getMemberCache().asList();
+            event.reply(gatherMemberStats(event.getGuild()).build());
+        }
+
+        private EmbedBuilder gatherMemberStats(Guild server) {
+            List<Member> members = server.getMemberCache().asList();
             Map<LocalDate, Integer> bestDays = new TreeMap<>();
 
             // Toss it all into the hashmap
@@ -610,7 +745,7 @@ public class ServerInfoCommand extends Command {
             LocalDate[] keys = bestDays.keySet().toArray(new LocalDate[0]);
 
             for (int i = 1; i < bestDays.size(); i++) {
-                LocalDate base = keys[i-1];
+                LocalDate base = keys[i - 1];
                 LocalDate compare = keys[i];
 
                 if (compare.toEpochDay() - base.toEpochDay() > slumpDays) {
@@ -628,14 +763,13 @@ public class ServerInfoCommand extends Command {
             }
 
             EmbedBuilder embed = new EmbedBuilder()
-                .setTitle("Member Stats for " + event.getGuild().getName())
+                .setTitle("Member Stats for " + server.getName())
                 .setDescription("A collection of simple stats for the server!");
 
             embed.addField("Most Members in A Day", "Members: " + best + "\n" + bestDay.stream().map(LocalDate::toString).collect(Collectors.joining("\n")), true);
             embed.addField("Largest Slump", "Days: " + slumpDays + "\nRange: " + startSlump + " - " + startSlump.atStartOfDay().plusDays(slumpDays).toLocalDate().toString(), true);
 
-            event.reply(embed.build());
+            return embed;
         }
     }
 }
-

--- a/src/main/java/pw/chew/chewbotcca/commands/minecraft/MCIssueCommand.java
+++ b/src/main/java/pw/chew/chewbotcca/commands/minecraft/MCIssueCommand.java
@@ -82,7 +82,11 @@ public class MCIssueCommand extends SlashCommand {
         }
 
         JSONObject data = new JSONObject(RestClient.get(apiUrl + issue));
-        event.replyEmbeds(generateEmbed(data, issue, apiUrl).build()).queue();
+        try {
+            event.replyEmbeds(generateEmbed(data, issue, apiUrl).build()).queue();
+        } catch (IllegalArgumentException e) {
+            event.reply(e.getMessage()).setEphemeral(true).queue();
+        }
     }
 
     @Override
@@ -102,7 +106,7 @@ public class MCIssueCommand extends SlashCommand {
         }
 
         String apiUrl = getApiUrl(issue.split("-")[0]);
-        if(apiUrl == null) {
+        if (apiUrl == null) {
             event.reply("Invalid Project Specified. Supported projects are any from Mojang Studios or SpigotMC Jira");
             return;
         }
@@ -111,15 +115,17 @@ public class MCIssueCommand extends SlashCommand {
 
         JSONObject data = new JSONObject(RestClient.get(apiUrl + issue));
 
-        event.reply(generateEmbed(data, issue, apiUrl).build());
+        try {
+            event.reply(generateEmbed(data, issue, apiUrl).build());
+        } catch (IllegalArgumentException e) {
+            event.replyWarning(e.getMessage());
+        }
     }
 
     public static EmbedBuilder generateEmbed(JSONObject data, String issue, String apiUrl) {
         EmbedBuilder embed = new EmbedBuilder();
         if(data.has("errorMessages")) {
-            embed.setTitle("Error!");
-            embed.setDescription(data.getJSONArray("errorMessages").getString(0));
-            return embed;
+            throw new IllegalArgumentException(data.getJSONArray("errorMessages").getString(0));
         }
 
         data = data.getJSONObject("fields");

--- a/src/main/java/pw/chew/chewbotcca/commands/minecraft/MCServerCommand.java
+++ b/src/main/java/pw/chew/chewbotcca/commands/minecraft/MCServerCommand.java
@@ -27,6 +27,7 @@ import net.dv8tion.jda.api.interactions.commands.build.OptionData;
 import org.jetbrains.annotations.Nullable;
 import org.json.JSONArray;
 import org.json.JSONObject;
+import pw.chew.chewbotcca.util.ResponseHelper;
 import pw.chew.chewbotcca.util.RestClient;
 
 import java.awt.Color;
@@ -50,7 +51,7 @@ public class MCServerCommand extends SlashCommand {
 
     @Override
     protected void execute(SlashCommandEvent event) {
-        String ip = event.getOption("ip").getAsString();
+        String ip = ResponseHelper.guaranteeStringOption(event, "ip", "");
         event.replyEmbeds(gatherServerData(ip)).queue();
     }
 

--- a/src/main/java/pw/chew/chewbotcca/commands/minecraft/MCStatusCommand.java
+++ b/src/main/java/pw/chew/chewbotcca/commands/minecraft/MCStatusCommand.java
@@ -16,10 +16,12 @@
  */
 package pw.chew.chewbotcca.commands.minecraft;
 
-import com.jagrosh.jdautilities.command.Command;
 import com.jagrosh.jdautilities.command.CommandEvent;
+import com.jagrosh.jdautilities.command.SlashCommand;
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.Permission;
+import net.dv8tion.jda.api.entities.MessageEmbed;
+import net.dv8tion.jda.api.events.interaction.SlashCommandEvent;
 import okhttp3.Request;
 import okhttp3.Response;
 import org.json.JSONArray;
@@ -32,17 +34,27 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-public class MCStatusCommand extends Command {
+public class MCStatusCommand extends SlashCommand {
 
     public MCStatusCommand() {
         this.name = "mcstatus";
+        this.help = "Gather Mojang/Minecraft server status";
         this.botPermissions = new Permission[]{Permission.MESSAGE_EMBED_LINKS};
         this.guildOnly = false;
     }
 
     @Override
+    protected void execute(SlashCommandEvent event) {
+        event.replyEmbeds(gatherStatus()).queue();
+    }
+
+    @Override
     protected void execute(CommandEvent commandEvent) {
         commandEvent.getChannel().sendTyping().queue();
+        commandEvent.reply(gatherStatus());
+    }
+
+    private MessageEmbed gatherStatus() {
         // Get stats
         JSONArray statusurl = new JSONArray(RestClient.get("https://status.mojang.com/check"));
         List<String> forbiddenSites = Collections.singletonList("sessionserver.mojang.com");
@@ -84,7 +96,7 @@ public class MCStatusCommand extends Command {
             e.addField("Down", String.join("\n", red), true);
         }
 
-        commandEvent.reply(e.build());
+        return e.build();
     }
 
     public boolean isUp(String url) {

--- a/src/main/java/pw/chew/chewbotcca/commands/minecraft/MCUserCommand.java
+++ b/src/main/java/pw/chew/chewbotcca/commands/minecraft/MCUserCommand.java
@@ -53,14 +53,22 @@ public class MCUserCommand extends SlashCommand {
     @Override
     protected void execute(SlashCommandEvent event) {
         String name = ResponseHelper.guaranteeStringOption(event, "user", "");
-        event.replyEmbeds(gatherData(name)).queue();
+        try {
+            event.replyEmbeds(gatherData(name)).queue();
+        } catch (IllegalArgumentException e) {
+            event.reply(e.getMessage()).setEphemeral(true).queue();
+        }
     }
 
     @Override
     protected void execute(CommandEvent commandEvent) {
         // Get username/uuid from args
         String name = commandEvent.getArgs().split(" ")[0].replace("-", "");
-        commandEvent.reply(gatherData(name));
+        try {
+            commandEvent.reply(gatherData(name));
+        } catch (IllegalArgumentException e) {
+            commandEvent.replyWarning(e.getMessage());
+        }
     }
 
     private MessageEmbed gatherData(String name) {

--- a/src/main/java/pw/chew/chewbotcca/commands/moderation/UnsuppressCommand.java
+++ b/src/main/java/pw/chew/chewbotcca/commands/moderation/UnsuppressCommand.java
@@ -28,6 +28,7 @@ public class UnsuppressCommand extends Command {
 
     public UnsuppressCommand() {
         this.name = "unsuppress";
+        this.help = "";
         this.botPermissions = new Permission[]{Permission.MESSAGE_MANAGE};
         this.userPermissions = new Permission[]{Permission.MESSAGE_MANAGE};
         this.guildOnly = true;

--- a/src/main/java/pw/chew/chewbotcca/commands/owner/ShutdownCommand.java
+++ b/src/main/java/pw/chew/chewbotcca/commands/owner/ShutdownCommand.java
@@ -18,6 +18,7 @@ package pw.chew.chewbotcca.commands.owner;
 
 import com.jagrosh.jdautilities.command.Command;
 import com.jagrosh.jdautilities.command.CommandEvent;
+import pw.chew.chewbotcca.objects.Memory;
 
 // %^shutdown command
 public class ShutdownCommand extends Command {
@@ -31,7 +32,11 @@ public class ShutdownCommand extends Command {
     protected void execute(CommandEvent commandEvent) {
         // whee
         commandEvent.getChannel().sendMessage("Shutting down....").queue((msg) -> {
-            msg.getGuild().updateCommands().queue();
+            if (Memory.getClient().forcedGuildId() == null) {
+                msg.getJDA().updateCommands().queue();
+            } else {
+                msg.getJDA().getGuildById(Memory.getClient().forcedGuildId()).updateCommands().queue();
+            }
             msg.getJDA().shutdown();
         });
     }

--- a/src/main/java/pw/chew/chewbotcca/commands/owner/ShutdownCommand.java
+++ b/src/main/java/pw/chew/chewbotcca/commands/owner/ShutdownCommand.java
@@ -30,6 +30,9 @@ public class ShutdownCommand extends Command {
     @Override
     protected void execute(CommandEvent commandEvent) {
         // whee
-        commandEvent.getChannel().sendMessage("Shutting down....").queue((msg) -> System.exit(0));
+        commandEvent.getChannel().sendMessage("Shutting down....").queue((msg) -> {
+            msg.getGuild().updateCommands().queue();
+            msg.getJDA().shutdown();
+        });
     }
 }

--- a/src/main/java/pw/chew/chewbotcca/commands/services/GitHubCommand.java
+++ b/src/main/java/pw/chew/chewbotcca/commands/services/GitHubCommand.java
@@ -1,0 +1,191 @@
+/*
+ * Copyright (C) 2021 Chewbotcca
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package pw.chew.chewbotcca.commands.services;
+
+import com.jagrosh.jdautilities.command.SlashCommand;
+import me.memerator.api.errors.NotFound;
+import net.dv8tion.jda.api.events.interaction.SlashCommandEvent;
+import net.dv8tion.jda.api.interactions.commands.OptionType;
+import net.dv8tion.jda.api.interactions.commands.build.OptionData;
+import org.kohsuke.github.GHDirection;
+import org.kohsuke.github.GHIssue;
+import org.kohsuke.github.GHRepository;
+import org.kohsuke.github.GHUser;
+import org.kohsuke.github.PagedIterator;
+import pw.chew.chewbotcca.objects.Memory;
+import pw.chew.chewbotcca.objects.UserProfile;
+import pw.chew.chewbotcca.util.ResponseHelper;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+
+import static pw.chew.chewbotcca.commands.services.github.GHIssueCommand.issueBuilder;
+import static pw.chew.chewbotcca.commands.services.github.GHRepoCommand.gatherRepoData;
+import static pw.chew.chewbotcca.commands.services.github.GHUserCommand.gatherUser;
+
+/**
+ * This command is exclusively to allow /github [subcommand]
+ * Normal command handling is done in the respective GitHub package
+ */
+public class GitHubCommand extends SlashCommand {
+
+    public GitHubCommand() {
+        this.name = "github";
+        this.help = "Gathers some info from GitHub";
+        this.children = new SlashCommand[]{
+            new GitHubIssueSubCommand(),
+            new GitHubRepoSubCommand(),
+            new GitHubUserCommand()
+        };
+    }
+
+    @Override
+    protected void execute(SlashCommandEvent event) {
+        // This is ignored as we delegate everything to sub-commands
+    }
+
+    public static class GitHubIssueSubCommand extends SlashCommand {
+
+        public GitHubIssueSubCommand() {
+            this.name = "issue";
+            this.help = "Gathers an issue from a repository on GitHub";
+            this.options = Arrays.asList(
+                new OptionData(OptionType.STRING, "repo", "The repo to look up (format: UserOrOrg/Repo)").setRequired(true),
+                new OptionData(OptionType.STRING, "issue", "The issue. Provide a number or search term").setRequired(true)
+            );
+        }
+
+        @Override
+        protected void execute(SlashCommandEvent event) {
+            GHIssue issue;
+
+            String repo = ResponseHelper.guaranteeStringOption(event, "repo", "");
+            String term = ResponseHelper.guaranteeStringOption(event, "issue", "");
+            try {
+                issue = parseMessage(repo, term);
+            } catch (IOException e) {
+                event.reply("Invalid issue number or an invalid repository was provided. Please ensure the issue exists and the repository is public.")
+                    .setEphemeral(true).queue();
+                return;
+            } catch (IllegalArgumentException e) {
+                event.reply(e.getMessage()).setEphemeral(true).queue();
+                return;
+            }
+            if(issue == null)
+                return;
+
+            // Create and send off an issue embed
+            event.replyEmbeds(issueBuilder(issue).build()).queue();
+        }
+
+        public GHIssue parseMessage(String repo, String term) throws IOException {
+            // Store GHIssue for later
+            GHIssue issue;
+            // Make sure the issue number is valid
+            int issueNum;
+            try {
+                issueNum = Integer.parseInt(term);
+                issue = Memory.getGithub().getRepository(repo).getIssue(issueNum);
+            } catch (NumberFormatException e) {
+                PagedIterator<GHIssue> iterator = Memory.getGithub().searchIssues()
+                    .q(term + " repo:" + repo)
+                    .order(GHDirection.DESC)
+                    .list()
+                    ._iterator(1);
+                if (iterator.hasNext()) {
+                    issue = iterator.next();
+                } else {
+                    throw new NotFound("Could not find specified issue in repo `" + repo + "`!");
+                }
+                int num = issue.getNumber();
+                issue = Memory.getGithub().getRepository(repo).getIssue(num);
+                return issue;
+            }
+            return issue;
+        }
+    }
+
+    public static class GitHubRepoSubCommand extends SlashCommand {
+
+        public GitHubRepoSubCommand() {
+            this.name = "repository";
+            this.help = "Gathers a repository from GitHub";
+            this.options = Collections.singletonList(
+                new OptionData(OptionType.STRING, "repo", "The repo to look up (format: UserOrOrg/Repo)").setRequired(true)
+            );
+        }
+
+        @Override
+        protected void execute(SlashCommandEvent event) {
+            // Get the repo
+            String repoName = ResponseHelper.guaranteeStringOption(event, "repo", "");
+            if (!repoName.contains("/")) {
+                event.reply("Make sure your input contains a UserOrOrg/RepositoryName (e.g. Chewbotcca/Discord).").setEphemeral(true).queue();
+                return;
+            }
+            // Find the repo
+            GHRepository repo;
+            try {
+                repo = Memory.getGithub().getRepository(repoName);
+            } catch (IOException e) {
+                event.reply("Invalid repository name. Please make sure this repository exists!").setEphemeral(true).queue();
+                return;
+            }
+            event.replyEmbeds(gatherRepoData(repo)).queue();
+        }
+    }
+
+    public static class GitHubUserCommand extends SlashCommand {
+
+        public GitHubUserCommand() {
+            this.name = "user";
+            this.help = "Gathers a user from GitHub";
+            this.options = Collections.singletonList(
+                new OptionData(OptionType.STRING, "username", "The user to look up (default: yours if set)").setRequired(true)
+            );
+        }
+
+        @Override
+        protected void execute(SlashCommandEvent event) {
+            // Get the input
+            String username = ResponseHelper.guaranteeStringOption(event, "username", "");
+            if (username.isBlank()) {
+                UserProfile profile = UserProfile.getProfile(event.getUser().getId());
+                if (profile.getGitHub() != null) {
+                    username = profile.getGitHub();
+                } else {
+                    event.reply("You don't have a GitHub username set on your profile. " +
+                            "Please specify a user with `/github user [name]` or set your username with `/profile set github [yourname]`!")
+                        .setEphemeral(true)
+                        .queue();
+                    return;
+                }
+            }
+
+            GHUser user;
+            try {
+                user = Memory.getGithub().getUser(username);
+            } catch (IOException e) {
+                event.reply("Invalid username. Please make sure this user exists!").setEphemeral(true).queue();
+                return;
+            }
+            event.replyEmbeds(gatherUser(user)).queue();
+        }
+    }
+}

--- a/src/main/java/pw/chew/chewbotcca/commands/services/GitHubSlashCommand.java
+++ b/src/main/java/pw/chew/chewbotcca/commands/services/GitHubSlashCommand.java
@@ -43,9 +43,9 @@ import static pw.chew.chewbotcca.commands.services.github.GHUserCommand.gatherUs
  * This command is exclusively to allow /github [subcommand]
  * Normal command handling is done in the respective GitHub package
  */
-public class GitHubCommand extends SlashCommand {
+public class GitHubSlashCommand extends SlashCommand {
 
-    public GitHubCommand() {
+    public GitHubSlashCommand() {
         this.name = "github";
         this.help = "Gathers some info from GitHub";
         this.children = new SlashCommand[]{

--- a/src/main/java/pw/chew/chewbotcca/commands/services/GitHubSlashCommand.java
+++ b/src/main/java/pw/chew/chewbotcca/commands/services/GitHubSlashCommand.java
@@ -51,7 +51,7 @@ public class GitHubSlashCommand extends SlashCommand {
         this.children = new SlashCommand[]{
             new GitHubIssueSubCommand(),
             new GitHubRepoSubCommand(),
-            new GitHubUserCommand()
+            new GitHubUserSubCommand()
         };
     }
 
@@ -151,9 +151,9 @@ public class GitHubSlashCommand extends SlashCommand {
         }
     }
 
-    public static class GitHubUserCommand extends SlashCommand {
+    public static class GitHubUserSubCommand extends SlashCommand {
 
-        public GitHubUserCommand() {
+        public GitHubUserSubCommand() {
             this.name = "user";
             this.help = "Gathers a user from GitHub";
             this.options = Collections.singletonList(

--- a/src/main/java/pw/chew/chewbotcca/commands/services/MemeratorCommand.java
+++ b/src/main/java/pw/chew/chewbotcca/commands/services/MemeratorCommand.java
@@ -85,7 +85,7 @@ public class MemeratorCommand extends SlashCommand {
         @Override
         protected void execute(SlashCommandEvent event) {
             try {
-                event.replyEmbeds(buildMemeEmbed(event.getOption("meme").getAsString(), event.getChannel())).queue();
+                event.replyEmbeds(buildMemeEmbed(ResponseHelper.guaranteeStringOption(event, "meme", ""), event.getChannel())).queue();
             } catch (IllegalArgumentException e) {
                 event.replyEmbeds(ResponseHelper.generateFailureEmbed("The meme machine ran dry...", e.getMessage()))
                     .setEphemeral(true)
@@ -187,7 +187,7 @@ public class MemeratorCommand extends SlashCommand {
         @Override
         protected void execute(SlashCommandEvent event) {
             try {
-                User user = api.getUser(event.getOption("user").getAsString());
+                User user = api.getUser(ResponseHelper.guaranteeStringOption(event, "user", ""));
                 event.replyEmbeds(generateUserEmbed(user).build()).queue();
             } catch (NotFound notFound) {
                 event.reply("User not found!").setEphemeral(true).queue();

--- a/src/main/java/pw/chew/chewbotcca/commands/services/RedditCommand.java
+++ b/src/main/java/pw/chew/chewbotcca/commands/services/RedditCommand.java
@@ -81,6 +81,7 @@ public class RedditCommand extends SlashCommand {
                 }
             case 2:
                 subreddit = args[1];
+            default:
         }
 
         try {

--- a/src/main/java/pw/chew/chewbotcca/commands/services/RedditCommand.java
+++ b/src/main/java/pw/chew/chewbotcca/commands/services/RedditCommand.java
@@ -16,42 +16,89 @@
  */
 package pw.chew.chewbotcca.commands.services;
 
-import com.jagrosh.jdautilities.command.Command;
 import com.jagrosh.jdautilities.command.CommandEvent;
+import com.jagrosh.jdautilities.command.SlashCommand;
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.Permission;
 import net.dv8tion.jda.api.entities.ChannelType;
+import net.dv8tion.jda.api.entities.MessageEmbed;
+import net.dv8tion.jda.api.events.interaction.SlashCommandEvent;
+import net.dv8tion.jda.api.interactions.commands.OptionType;
+import net.dv8tion.jda.api.interactions.commands.build.OptionData;
 import org.json.JSONArray;
 import org.json.JSONObject;
+import pw.chew.chewbotcca.util.ResponseHelper;
 import pw.chew.chewbotcca.util.RestClient;
 
 import java.time.Instant;
+import java.util.Arrays;
 import java.util.Random;
 
 // %^reddit command
-public class RedditCommand extends Command {
+public class RedditCommand extends SlashCommand {
 
     public RedditCommand() {
         this.name = "reddit";
+        this.help = "Searches for and returns a post from reddit";
         this.botPermissions = new Permission[]{Permission.MESSAGE_EMBED_LINKS};
         this.guildOnly = false;
+        this.options = Arrays.asList(
+            new OptionData(OptionType.INTEGER, "number", "The post number to grab").setRequired(true),
+            new OptionData(OptionType.STRING, "subreddit", "The subreddit to get a post from")
+        );
+    }
+
+    @Override
+    protected void execute(SlashCommandEvent event) {
+        int num = (int) event.getOptionsByName("number").get(0).getAsLong();
+        String subreddit = ResponseHelper.guaranteeStringOption(event, "subreddit", "");
+        boolean nsfwAllowed = event.getChannelType() == ChannelType.TEXT && !event.getTextChannel().isNSFW();
+
+        try {
+            event.replyEmbeds(gatherData(num, subreddit, nsfwAllowed)).queue();
+        } catch (IllegalArgumentException e) {
+            event.reply(e.getMessage()).setEphemeral(true).queue();
+        }
     }
 
     @Override
     protected void execute(CommandEvent commandEvent) {
+        String[] args = commandEvent.getArgs().split(" ");
+        boolean nsfwAllowed = commandEvent.getChannelType() == ChannelType.TEXT && !commandEvent.getTextChannel().isNSFW();
+
+        int num = -1;
+        String subreddit = "";
+        switch (args.length) {
+            case 0:
+                commandEvent.replyWarning("This command requires at least 1 argument! Post number and subreddit (optional)");
+                return;
+            case 1:
+                try {
+                    num = Integer.parseInt(args[0]);
+                } catch (NumberFormatException e) {
+                    commandEvent.replyWarning("First argument must be a number!");
+                    return;
+                }
+            case 2:
+                subreddit = args[1];
+        }
+
+        try {
+            commandEvent.reply(gatherData(num, subreddit, nsfwAllowed));
+        } catch (IllegalArgumentException e) {
+            commandEvent.replyWarning(e.getMessage());
+        }
+    }
+
+    private MessageEmbed gatherData(int num, String subreddit, boolean nsfwAllowed) {
         String baseUrl = "https://reddit.com/r/%s/.json";
         String url;
-        int num = -1;
         // If no args, just use the front page json
-        if(commandEvent.getArgs().length() == 0) {
+        if (subreddit.isBlank()) {
             url = "https://reddit.com/.json";
         } else {
             // Otherwise, a subreddit was probably specified, so use that
-            String[] args = commandEvent.getArgs().split(" ");
-            url = String.format(baseUrl, args[0].replace("r/", ""));
-            if(args.length > 1) {
-                num = Integer.parseInt(args[1]);
-            }
+            url = String.format(baseUrl, subreddit.replace("r/", ""));
         }
 
         // Get data from reddit
@@ -59,18 +106,16 @@ public class RedditCommand extends Command {
         JSONArray data = reddit.getJSONObject("data").getJSONArray("children");
 
         if (data.length() == 0) {
-            commandEvent.reply("This sub-reddit does not have any posts!");
-            return;
+            throw new IllegalArgumentException("This sub-reddit does not have any posts!");
         }
 
         JSONObject post;
 
         // If the specified post is greater than the actual amount of posts
-        if(num >= 0 && data.length() >= num) {
+        if (num >= 0 && data.length() >= num) {
             post = data.getJSONObject(num);
-        } else if(num >= 0) {
-            commandEvent.reply("Number too large! Pick a number between 1 and " + data.length());
-            return;
+        } else if (num >= 0) {
+            throw new IllegalArgumentException("Number too large! Pick a number between 1 and " + data.length());
         } else {
             post = getRandom(data);
         }
@@ -79,12 +124,11 @@ public class RedditCommand extends Command {
         JSONObject postData = post.getJSONObject("data");
 
         // If it's over 18 and it's not an NSFW channel, don't show it
-        if(postData.getBoolean("over_18") && commandEvent.getChannelType() == ChannelType.TEXT && !commandEvent.getTextChannel().isNSFW()) {
-            commandEvent.reply("This post is marked as NSFW and must be ran in a NSFW channel!");
-            return;
+        if (postData.getBoolean("over_18") && nsfwAllowed) {
+            throw new IllegalArgumentException("This post is marked as NSFW and must be ran in a NSFW channel!");
         }
 
-        commandEvent.reply(generatePostEmbed(postData).build());
+        return generatePostEmbed(postData).build();
     }
 
     // Code to generate a post embed based off of a post json object

--- a/src/main/java/pw/chew/chewbotcca/commands/services/github/GHIssueCommand.java
+++ b/src/main/java/pw/chew/chewbotcca/commands/services/github/GHIssueCommand.java
@@ -69,14 +69,15 @@ public class GHIssueCommand extends Command {
 
     /**
      * Method to make an issue embed
+     *
      * @param issue the issue to parse
      * @return an EmbedBuilder with all the data
      */
-    public EmbedBuilder issueBuilder(GHIssue issue) {
+    public static EmbedBuilder issueBuilder(GHIssue issue) {
         EmbedBuilder e = new EmbedBuilder();
         // Set the title and body to the issue title and body
         e.setTitle(issue.getTitle(), String.valueOf(issue.getHtmlUrl()));
-        if(issue.getBody() != null) {
+        if (issue.getBody() != null) {
             if (issue.getBody().length() > 400) {
                 e.setDescription(issue.getBody().substring(0, 399) + "...");
             } else {

--- a/src/main/java/pw/chew/chewbotcca/commands/services/github/GHRepoCommand.java
+++ b/src/main/java/pw/chew/chewbotcca/commands/services/github/GHRepoCommand.java
@@ -20,6 +20,7 @@ import com.jagrosh.jdautilities.command.Command;
 import com.jagrosh.jdautilities.command.CommandEvent;
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.Permission;
+import net.dv8tion.jda.api.entities.MessageEmbed;
 import org.kohsuke.github.GHRepository;
 import pw.chew.chewbotcca.objects.Memory;
 
@@ -40,7 +41,7 @@ public class GHRepoCommand extends Command {
     protected void execute(CommandEvent commandEvent) {
         // Get the repo
         String repoName = commandEvent.getArgs();
-        if(!repoName.contains("/")) {
+        if (!repoName.contains("/")) {
             commandEvent.reply("Make sure your input contains a UserOrOrg/RepositoryName (e.g. Chewbotcca/Discord).");
             return;
         }
@@ -53,15 +54,19 @@ public class GHRepoCommand extends Command {
             commandEvent.reply("Invalid repository name. Please make sure this repository exists!");
             return;
         }
+        commandEvent.reply(gatherRepoData(repo));
+    }
+
+    public static MessageEmbed gatherRepoData(GHRepository repo) {
         // Generate an Embed
         EmbedBuilder e = new EmbedBuilder();
         try {
             // Set data based on repo info
             e.setTitle("GitHub Repository Info for " + repo.getFullName(), "https://github.com/" + repo.getFullName());
             e.setDescription(repo.getDescription());
-            if(repo.getHomepage() != null)
+            if (repo.getHomepage() != null)
                 e.addField("URL", String.valueOf(repo.getHomepage()), true);
-            if(repo.getLicense() != null)
+            if (repo.getLicense() != null)
                 e.addField("License", repo.getLicense().getName(), true);
             e.addField("Open Issues/PRs", String.valueOf(repo.getOpenIssueCount()), true);
             e.addField("Stars", String.valueOf(repo.getStargazersCount()), true);
@@ -83,6 +88,6 @@ public class GHRepoCommand extends Command {
             ioException.printStackTrace();
         }
 
-        commandEvent.reply(e.build());
+        return e.build();
     }
 }

--- a/src/main/java/pw/chew/chewbotcca/commands/services/github/GHUserCommand.java
+++ b/src/main/java/pw/chew/chewbotcca/commands/services/github/GHUserCommand.java
@@ -20,6 +20,7 @@ import com.jagrosh.jdautilities.command.Command;
 import com.jagrosh.jdautilities.command.CommandEvent;
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.Permission;
+import net.dv8tion.jda.api.entities.MessageEmbed;
 import org.kohsuke.github.GHOrganization;
 import org.kohsuke.github.GHUser;
 import pw.chew.chewbotcca.objects.Memory;
@@ -41,7 +42,7 @@ public class GHUserCommand extends Command {
     protected void execute(CommandEvent commandEvent) {
         // Get the input
         String username = commandEvent.getArgs();
-        if(username.isBlank()) {
+        if (username.isBlank()) {
             UserProfile profile = UserProfile.getProfile(commandEvent.getAuthor().getId());
             if (profile.getGitHub() != null) {
                 username = profile.getGitHub();
@@ -60,6 +61,10 @@ public class GHUserCommand extends Command {
             commandEvent.reply("Invalid username. Please make sure this user exists!");
             return;
         }
+        commandEvent.reply(gatherUser(user));
+    }
+
+    public static MessageEmbed gatherUser(GHUser user) {
         // Generate Embed
         EmbedBuilder e = new EmbedBuilder();
         try {
@@ -68,7 +73,7 @@ public class GHUserCommand extends Command {
             e.addField("Repositories", String.valueOf(user.getPublicRepoCount()), true);
             // If it's actually an org, handle it differently
             boolean isOrg = user.getType().equals("Organization");
-            if(!isOrg) {
+            if (!isOrg) {
                 // If it's not an org, it's a profile!
                 e.setTitle("GitHub profile for " + user.getLogin(), "https://github.com/" + user.getLogin());
                 e.setDescription(user.getBio());
@@ -90,7 +95,7 @@ public class GHUserCommand extends Command {
             ioException.printStackTrace();
         }
 
-        commandEvent.reply(e.build());
+        return e.build();
     }
 
 }

--- a/src/main/java/pw/chew/chewbotcca/commands/services/google/YouTubeCommand.java
+++ b/src/main/java/pw/chew/chewbotcca/commands/services/google/YouTubeCommand.java
@@ -50,6 +50,7 @@ public class YouTubeCommand extends SlashCommand {
 
     public YouTubeCommand() {
         this.name = "youtube";
+        this.help = "Queries YouTube for a video";
         this.aliases = new String[]{"yt"};
         this.botPermissions = new Permission[]{Permission.MESSAGE_EMBED_LINKS};
         this.guildOnly = false;

--- a/src/main/java/pw/chew/chewbotcca/commands/services/google/YouTubeCommand.java
+++ b/src/main/java/pw/chew/chewbotcca/commands/services/google/YouTubeCommand.java
@@ -67,7 +67,7 @@ public class YouTubeCommand extends SlashCommand {
 
     @Override
     protected void execute(SlashCommandEvent event) {
-        event.replyEmbeds(gatherInfo(event.getOption("query").getAsString(), event.getChannel())).queue();
+        event.replyEmbeds(gatherInfo(ResponseHelper.guaranteeStringOption(event, "query", ""), event.getChannel())).queue();
     }
 
     /**

--- a/src/main/java/pw/chew/chewbotcca/commands/settings/ProfileCommand.java
+++ b/src/main/java/pw/chew/chewbotcca/commands/settings/ProfileCommand.java
@@ -16,22 +16,39 @@
  */
 package pw.chew.chewbotcca.commands.settings;
 
-import com.jagrosh.jdautilities.command.Command;
 import com.jagrosh.jdautilities.command.CommandEvent;
+import com.jagrosh.jdautilities.command.SlashCommand;
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.Permission;
+import net.dv8tion.jda.api.entities.MessageEmbed;
+import net.dv8tion.jda.api.events.interaction.SlashCommandEvent;
+import net.dv8tion.jda.api.interactions.commands.Command;
+import net.dv8tion.jda.api.interactions.commands.OptionType;
+import net.dv8tion.jda.api.interactions.commands.build.OptionData;
 import pw.chew.chewbotcca.objects.UserProfile;
+import pw.chew.chewbotcca.util.ResponseHelper;
 
 import java.util.Arrays;
 import java.util.List;
 
 // %^profile command
-public class ProfileCommand extends Command {
+public class ProfileCommand extends SlashCommand {
 
     public ProfileCommand() {
         this.name = "profile";
+        this.help = "Gets your own bot profile.";
         this.botPermissions = new Permission[]{Permission.MESSAGE_EMBED_LINKS};
         this.guildOnly = false;
+        this.children = new SlashCommand[]{
+            new GetProfileSubCommand(),
+            new SetProfileSubCommand(),
+            new DeleteProfileSubCommand()
+        };
+    }
+
+    @Override
+    protected void execute(SlashCommandEvent event) {
+        // Not executed because slash commands with children don't have root commands
     }
 
     @Override
@@ -40,39 +57,123 @@ public class ProfileCommand extends Command {
         commandEvent.getChannel().sendTyping().queue();
         // Get Bot Profile details and send
         UserProfile profile = UserProfile.retrieveProfile(commandEvent.getAuthor().getId());
-        if(commandEvent.getArgs().equals("delete")) {
+        commandEvent.reply(getProfileData(profile, commandEvent.getPrefix()));
+    }
+
+    private MessageEmbed getProfileData(UserProfile profile, String prefix) {
+        EmbedBuilder embed = new EmbedBuilder()
+            .setTitle("Your Chewbotcca Profile")
+            .setDescription("The profile system is a work in progress! More details will appear soon!")
+            .setFooter("ID: " + profile.getId());
+
+        embed.addField("Lastfm Username", profile.getLastFm() == null ? "Set with `" + prefix + "profile set lastfm [name]`" : profile.getLastFm(), true);
+        embed.addField("GitHub Username", profile.getGitHub() == null ? "Set with `" + prefix + "profile set github [name]`" : profile.getGitHub(), true);
+
+        return embed.build();
+    }
+
+    private class GetProfileSubCommand extends SlashCommand {
+
+        private GetProfileSubCommand() {
+            this.name = "get";
+            this.help = "Gets your bot profile";
+            this.botPermissions = new Permission[]{Permission.MESSAGE_EMBED_LINKS};
+            this.guildOnly = false;
+        }
+
+        @Override
+        protected void execute(SlashCommandEvent event) {
+            // Get Bot Profile details and send
+            UserProfile profile = UserProfile.retrieveProfile(event.getUser().getId());
+            event.replyEmbeds(getProfileData(profile, "/")).setEphemeral(true).queue();
+        }
+
+        @Override
+        protected void execute(CommandEvent event) {
+            // Get Bot Profile details and send
+            UserProfile profile = UserProfile.retrieveProfile(event.getAuthor().getId());
+            event.reply(getProfileData(profile, "/"));
+        }
+    }
+
+    private static class SetProfileSubCommand extends SlashCommand {
+
+        private SetProfileSubCommand() {
+            this.name = "set";
+            this.help = "Changes information associated with your bot profile";
+            this.botPermissions = new Permission[]{Permission.MESSAGE_EMBED_LINKS};
+            this.guildOnly = false;
+
+            this.options = Arrays.asList(
+                new OptionData(OptionType.STRING, "key", "Which key to modify")
+                    .setRequired(true)
+                    .addChoices(
+                        new Command.Choice("Last.fm Username", "lastfm"),
+                        new Command.Choice("GitHub Username", "github")
+                    ),
+                new OptionData(OptionType.STRING, "value", "The value to set").setRequired(true)
+            );
+        }
+
+        @Override
+        protected void execute(SlashCommandEvent event) {
+            // Get Bot Profile details and send
+            UserProfile profile = UserProfile.retrieveProfile(event.getUser().getId());
+
+            profile.saveData(
+                ResponseHelper.guaranteeStringOption(event, "key", ""),
+                ResponseHelper.guaranteeStringOption(event, "value", "")
+            );
+
+            event.reply("If you see this message, then it saved successfully... hopefully.").setEphemeral(true).queue();
+        }
+
+        @Override
+        protected void execute(CommandEvent event) {
+            // Get Bot Profile details and send
+            UserProfile profile = UserProfile.retrieveProfile(event.getAuthor().getId());
+
+            String[] args = event.getArgs().split(" ");
+            if (args.length < 3) {
+                event.reply("""
+                    You are missing arguments! Must have `set`, `key`, `value`. Possible keys:
+                    ```
+                    lastfm - Your last.fm username for %^lastfm
+                    github - Your GitHub username for %^ghuser
+                    ```""".replaceAll("%\\^", event.getPrefix()));
+                return;
+            }
+            List<String> supported = Arrays.asList("github", "lastfm");
+            if (supported.contains(args[1].toLowerCase())) {
+                profile.saveData(args[1].toLowerCase(), args[2]);
+                event.reply("If you see this message, then it saved successfully... hopefully.");
+            } else {
+                event.reply("Unsupported argument!");
+            }
+        }
+    }
+
+    private static class DeleteProfileSubCommand extends SlashCommand {
+
+        private DeleteProfileSubCommand() {
+            this.name = "delete";
+            this.help = "Deletes all information associated with your bot profile";
+            this.botPermissions = new Permission[]{Permission.MESSAGE_EMBED_LINKS};
+            this.guildOnly = false;
+        }
+
+        @Override
+        protected void execute(SlashCommandEvent event) {
+            UserProfile profile = UserProfile.retrieveProfile(event.getUser().getId());
             profile.delete();
-            commandEvent.reply("Your profile has been deleted from the database!");
-            return;
+            event.reply("Your profile has been deleted from the database!").setEphemeral(true).queue();
         }
-        if(!commandEvent.getArgs().contains("set")) {
-            EmbedBuilder embed = new EmbedBuilder()
-                    .setTitle("Your Chewbotcca Profile")
-                    .setDescription("The profile system is a work in progress! More details will appear soon!")
-                    .setFooter("ID: " + profile.getId());
 
-            embed.addField("Lastfm Username", profile.getLastFm() == null ? "Set with `" + commandEvent.getPrefix() + "profile set lastfm [name]`" : profile.getLastFm(), true);
-            embed.addField("GitHub Username", profile.getGitHub() == null ? "Set with `" + commandEvent.getPrefix() + "profile set github [name]`" : profile.getGitHub(), true);
-
-            commandEvent.reply(embed.build());
-            return;
-        }
-        String[] args = commandEvent.getArgs().split(" ");
-        if(args.length < 3) {
-            commandEvent.reply("""
-                You are missing arguments! Must have `set`, `key`, `value`. Possible keys:
-                ```
-                lastfm - Your last.fm username for %^lastfm
-                github - Your GitHub username for %^ghuser
-                ```""".replaceAll("%\\^", commandEvent.getPrefix()));
-            return;
-        }
-        List<String> supported = Arrays.asList("github", "lastfm");
-        if(supported.contains(args[1].toLowerCase())) {
-            profile.saveData(args[1].toLowerCase(), args[2]);
-            commandEvent.reply("If you see this message, then it saved successfully... hopefully.");
-        } else {
-            commandEvent.reply("Unsupported argument!");
+        @Override
+        protected void execute(CommandEvent event) {
+            UserProfile profile = UserProfile.retrieveProfile(event.getAuthor().getId());
+            profile.delete();
+            event.reply("Your profile has been deleted from the database!");
         }
     }
 }

--- a/src/main/java/pw/chew/chewbotcca/commands/settings/ServerSettingsCommand.java
+++ b/src/main/java/pw/chew/chewbotcca/commands/settings/ServerSettingsCommand.java
@@ -16,24 +16,40 @@
  */
 package pw.chew.chewbotcca.commands.settings;
 
-import com.jagrosh.jdautilities.command.Command;
 import com.jagrosh.jdautilities.command.CommandEvent;
+import com.jagrosh.jdautilities.command.SlashCommand;
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.Permission;
 import net.dv8tion.jda.api.entities.Guild;
+import net.dv8tion.jda.api.entities.MessageEmbed;
+import net.dv8tion.jda.api.events.interaction.SlashCommandEvent;
+import net.dv8tion.jda.api.interactions.commands.Command;
+import net.dv8tion.jda.api.interactions.commands.OptionType;
+import net.dv8tion.jda.api.interactions.commands.build.OptionData;
 import pw.chew.chewbotcca.objects.ServerSettings;
+import pw.chew.chewbotcca.util.ResponseHelper;
 
 import java.util.Arrays;
 import java.util.List;
 
 // %^serversettings command
-public class ServerSettingsCommand extends Command {
+public class ServerSettingsCommand extends SlashCommand {
+
     public ServerSettingsCommand() {
         this.name = "serversettings";
         this.aliases = new String[]{"settings", "ss"};
         this.botPermissions = new Permission[]{Permission.MESSAGE_EMBED_LINKS};
         this.userPermissions = new Permission[]{Permission.MANAGE_SERVER};
         this.guildOnly = true;
+        this.children = new SlashCommand[]{
+            new GetServerSettingsSubCommand(),
+            new SetServerSettingsSubCommand()
+        };
+    }
+
+    @Override
+    protected void execute(SlashCommandEvent event) {
+        // Not executed because slash commands with children don't have root commands
     }
 
     @Override
@@ -43,34 +59,97 @@ public class ServerSettingsCommand extends Command {
         // Get server and its settings and return info
         Guild ser = commandEvent.getGuild();
         ServerSettings server = ServerSettings.retrieveServer(ser.getId());
-        if(!commandEvent.getArgs().contains("set")) {
-            EmbedBuilder embed = new EmbedBuilder()
-                .setTitle("Server Settings for " + ser.getName())
-                .setDescription("To set an option, execute `" + commandEvent.getPrefix() + "ss set option value`.\n" +
-                    "To view a list of valid options, simply run `" + commandEvent.getPrefix() + "ss set` " +
-                    "or visit the [wiki](https://wiki.chew.pro/index.php/Commands/serversettings)")
-                .setFooter("ID: " + server.getId());
+        commandEvent.reply(getServerData(server, commandEvent.getGuild(), commandEvent.getPrefix()));
+    }
 
-            embed.addField("Prefix", server.getPrefix() == null ? "Set with `" + commandEvent.getPrefix() + "settings set prefix [prefix]`" : server.getPrefix(), true);
+    private MessageEmbed getServerData(ServerSettings server, Guild ser, String prefix) {
+        EmbedBuilder embed = new EmbedBuilder()
+            .setTitle("Server Settings for " + ser.getName())
+            .setDescription("To set an option, execute `" + prefix + "serversettings set option value`.\n" +
+                "To view a list of valid options, simply run `" + prefix + "serversettings set` " +
+                "or visit the [wiki](https://wiki.chew.pro/index.php/Commands/serversettings)")
+            .setFooter("ID: " + server.getId());
 
-            commandEvent.reply(embed.build());
-            return;
+        embed.addField("Prefix", server.getPrefix() == null ? "Set with `" + prefix + "serversettings set prefix [prefix]`" : server.getPrefix(), true);
+
+        return embed.build();
+    }
+
+    private class GetServerSettingsSubCommand extends SlashCommand {
+
+        private GetServerSettingsSubCommand() {
+            this.name = "get";
+            this.help = "Gets this server's settings";
+            this.botPermissions = new Permission[]{Permission.MESSAGE_EMBED_LINKS};
+            this.userPermissions = new Permission[]{Permission.MANAGE_SERVER};
+            this.guildOnly = false;
         }
-        String[] args = commandEvent.getArgs().split(" ");
-        if(args.length < 3) {
-            commandEvent.reply("""
-                You are missing arguments! Must have `set`, `key`, `value`. Possible keys:
-                ```
-                prefix - The custom server prefix
-                ```""");
-            return;
+
+        @Override
+        protected void execute(SlashCommandEvent event) {
+            Guild ser = event.getGuild();
+            ServerSettings server = ServerSettings.retrieveServer(ser.getId());
+            event.replyEmbeds(getServerData(server, event.getGuild(), "/")).queue();
         }
-        List<String> supported = Arrays.asList("prefix");
-        if(supported.contains(args[1].toLowerCase())) {
-            server.saveData(args[1].toLowerCase(), args[2]);
-            commandEvent.reply("If you see this message, then it saved successfully... hopefully.");
-        } else {
-            commandEvent.reply("Invalid argument!");
+
+        @Override
+        protected void execute(CommandEvent event) {
+            Guild ser = event.getGuild();
+            ServerSettings server = ServerSettings.retrieveServer(ser.getId());
+            event.reply(getServerData(server, event.getGuild(), event.getPrefix()));
+        }
+    }
+
+    private static class SetServerSettingsSubCommand extends SlashCommand {
+
+        private SetServerSettingsSubCommand() {
+            this.name = "set";
+            this.help = "Changes information associated with this server's settings";
+            this.botPermissions = new Permission[]{Permission.MESSAGE_EMBED_LINKS};
+            this.guildOnly = false;
+
+            this.options = Arrays.asList(
+                new OptionData(OptionType.STRING, "key", "Which key to modify")
+                    .setRequired(true)
+                    .addChoices(
+                        new Command.Choice("Custom Prefix (for normal commands)", "prefix")
+                    ),
+                new OptionData(OptionType.STRING, "value", "The value to set").setRequired(true)
+            );
+        }
+
+        @Override
+        protected void execute(SlashCommandEvent event) {
+            // Get Bot Profile details and send
+            ServerSettings server = ServerSettings.retrieveServer(event.getGuild().getId());
+
+            server.saveData(
+                ResponseHelper.guaranteeStringOption(event, "key", ""),
+                ResponseHelper.guaranteeStringOption(event, "value", "")
+            );
+
+            event.reply("If you see this message, then it saved successfully... hopefully.").setEphemeral(true).queue();
+        }
+
+        @Override
+        protected void execute(CommandEvent event) {
+            ServerSettings server = ServerSettings.retrieveServer(event.getGuild().getId());
+            String[] args = event.getArgs().split(" ");
+            if (args.length < 3) {
+                event.reply("""
+                    You are missing arguments! Must have `set`, `key`, `value`. Possible keys:
+                    ```
+                    prefix - The custom server prefix
+                    ```""");
+                return;
+            }
+            List<String> supported = Arrays.asList("prefix");
+            if (supported.contains(args[1].toLowerCase())) {
+                server.saveData(args[1].toLowerCase(), args[2]);
+                event.reply("If you see this message, then it saved successfully... hopefully.");
+            } else {
+                event.reply("Invalid argument!");
+            }
         }
     }
 }

--- a/src/main/java/pw/chew/chewbotcca/commands/util/DefineCommand.java
+++ b/src/main/java/pw/chew/chewbotcca/commands/util/DefineCommand.java
@@ -54,9 +54,17 @@ public class DefineCommand extends SlashCommand {
         String word = ResponseHelper.guaranteeStringOption(event, "word", "");
 
         // Send message then edit it
+        EmbedPaginator paginator;
+        try {
+            paginator = buildPaginator(word, event.getUser());
+        } catch (IllegalArgumentException e) {
+            event.reply(e.getMessage()).setEphemeral(true).queue();
+            return;
+        }
+
         event.replyEmbeds(new EmbedBuilder().setDescription("Checking the dictionary...").build()).queue(interactionHook -> {
             interactionHook.retrieveOriginal().queue(message -> {
-                buildPaginator(word, event.getUser()).paginate(message, 1);
+                paginator.paginate(message, 1);
             });
         });
     }
@@ -67,7 +75,11 @@ public class DefineCommand extends SlashCommand {
         String word = commandEvent.getArgs();
 
         // Send message then edit it
-        buildPaginator(word, commandEvent.getAuthor()).paginate(commandEvent.getChannel(), 1);
+        try {
+            buildPaginator(word, commandEvent.getAuthor()).paginate(commandEvent.getChannel(), 1);
+        } catch (IllegalArgumentException e) {
+            commandEvent.replyWarning(e.getMessage());
+        }
     }
 
     private EmbedPaginator buildPaginator(String word, User author) {

--- a/src/main/java/pw/chew/chewbotcca/commands/util/DefineCommand.java
+++ b/src/main/java/pw/chew/chewbotcca/commands/util/DefineCommand.java
@@ -16,11 +16,15 @@
  */
 package pw.chew.chewbotcca.commands.util;
 
-import com.jagrosh.jdautilities.command.Command;
 import com.jagrosh.jdautilities.command.CommandEvent;
+import com.jagrosh.jdautilities.command.SlashCommand;
 import com.jagrosh.jdautilities.menu.EmbedPaginator;
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.Permission;
+import net.dv8tion.jda.api.entities.User;
+import net.dv8tion.jda.api.events.interaction.SlashCommandEvent;
+import net.dv8tion.jda.api.interactions.commands.OptionType;
+import net.dv8tion.jda.api.interactions.commands.build.OptionData;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -28,30 +32,54 @@ import pw.chew.chewbotcca.util.JDAUtilUtil;
 import pw.chew.chewbotcca.util.PropertiesManager;
 import pw.chew.chewbotcca.util.RestClient;
 
+import java.util.Collections;
+
 // %^define command
-public class DefineCommand extends Command {
+public class DefineCommand extends SlashCommand {
 
     public DefineCommand() {
         this.name = "define";
         this.botPermissions = new Permission[]{Permission.MESSAGE_EMBED_LINKS};
         this.guildOnly = false;
+        this.help = "Defines a word.";
+        this.options = Collections.singletonList(
+            new OptionData(OptionType.STRING, "word", "The word to define").setRequired(true)
+        );
+    }
+
+    @Override
+    protected void execute(SlashCommandEvent event) {
+        // Get the word from the command
+        String word = event.getOption("word").getAsString();
+
+        // Send message then edit it
+        event.replyEmbeds(new EmbedBuilder().setDescription("Checking the dictionary...").build()).queue(interactionHook -> {
+            interactionHook.retrieveOriginal().queue(message -> {
+                buildPaginator(word, event.getUser()).paginate(message, 1);
+            });
+        });
     }
 
     @Override
     protected void execute(CommandEvent commandEvent) {
         // Get the word from the command
         String word = commandEvent.getArgs();
+
+        // Send message then edit it
+        buildPaginator(word, commandEvent.getAuthor()).paginate(commandEvent.getChannel(), 1);
+    }
+
+    private EmbedPaginator buildPaginator(String word, User author) {
         // Attempt to grab the word, if it doesn't exist let them know
         JSONArray grabbedword;
         try {
             grabbedword = new JSONArray(RestClient.get("https://api.wordnik.com/v4/word.json/" + word + "/definitions?includeRelated=true&useCanonical=false&includeTags=false&api_key=" + PropertiesManager.getWordnikToken()));
         } catch(JSONException e) {
-            commandEvent.reply("Word not found! Check your local spell-checker!");
-            return;
+            throw new IllegalArgumentException("Word not found! Check your local spell-checker!");
         }
 
         EmbedPaginator.Builder paginator = JDAUtilUtil.makeEmbedPaginator();
-        paginator.setUsers(commandEvent.getAuthor());
+        paginator.setUsers(author);
 
         int definitions = grabbedword.length();
 
@@ -94,6 +122,6 @@ public class DefineCommand extends Command {
         }
         // Send it off!
         paginator.setText("");
-        paginator.build().paginate(commandEvent.getChannel(), 1);
+        return paginator.build();
     }
 }

--- a/src/main/java/pw/chew/chewbotcca/commands/util/DefineCommand.java
+++ b/src/main/java/pw/chew/chewbotcca/commands/util/DefineCommand.java
@@ -30,6 +30,7 @@ import org.json.JSONException;
 import org.json.JSONObject;
 import pw.chew.chewbotcca.util.JDAUtilUtil;
 import pw.chew.chewbotcca.util.PropertiesManager;
+import pw.chew.chewbotcca.util.ResponseHelper;
 import pw.chew.chewbotcca.util.RestClient;
 
 import java.util.Collections;
@@ -50,7 +51,7 @@ public class DefineCommand extends SlashCommand {
     @Override
     protected void execute(SlashCommandEvent event) {
         // Get the word from the command
-        String word = event.getOption("word").getAsString();
+        String word = ResponseHelper.guaranteeStringOption(event, "word", "");
 
         // Send message then edit it
         event.replyEmbeds(new EmbedBuilder().setDescription("Checking the dictionary...").build()).queue(interactionHook -> {

--- a/src/main/java/pw/chew/chewbotcca/commands/util/QuoteCommand.java
+++ b/src/main/java/pw/chew/chewbotcca/commands/util/QuoteCommand.java
@@ -16,25 +16,53 @@
  */
 package pw.chew.chewbotcca.commands.util;
 
-import com.jagrosh.jdautilities.command.Command;
 import com.jagrosh.jdautilities.command.CommandEvent;
+import com.jagrosh.jdautilities.command.SlashCommand;
 import net.dv8tion.jda.api.EmbedBuilder;
+import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.Permission;
 import net.dv8tion.jda.api.entities.ChannelType;
 import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.entities.MessageChannel;
+import net.dv8tion.jda.api.entities.MessageEmbed;
 import net.dv8tion.jda.api.entities.TextChannel;
+import net.dv8tion.jda.api.events.interaction.SlashCommandEvent;
 import net.dv8tion.jda.api.exceptions.ErrorResponseException;
+import net.dv8tion.jda.api.interactions.commands.OptionType;
+import net.dv8tion.jda.api.interactions.commands.build.OptionData;
 import pw.chew.chewbotcca.util.Mention;
+import pw.chew.chewbotcca.util.ResponseHelper;
+
+import java.util.Collections;
 
 // %^quote
-public class QuoteCommand extends Command {
+public class QuoteCommand extends SlashCommand {
 
     public QuoteCommand() {
         this.name = "quote";
+        this.help = "References a message from a server/channel this bot is in and can view";
         this.botPermissions = new Permission[]{Permission.MESSAGE_EMBED_LINKS};
         this.guildOnly = false;
+        this.options = Collections.singletonList(
+            new OptionData(OptionType.STRING, "message_link", "The link (Copy URL) of a message to reference").setRequired(true)
+        );
+    }
+
+    @Override
+    protected void execute(SlashCommandEvent event) {
+        Message message;
+        String[] link = ResponseHelper.guaranteeStringOption(event, "message_link", "").split("/");
+        try {
+            message = retrieveMessageFromLink(link, event.getJDA());
+        } catch (IllegalArgumentException e) {
+            event.reply("Could not get message! " + e.getMessage()).setEphemeral(true).queue();
+            return;
+        }
+
+        boolean thisGuild = event.getGuild() != null && event.getGuild().getId().equals(message.getGuild().getId());
+        boolean thisChannel = event.getChannel().getId().equals(message.getChannel().getId());
+        event.replyEmbeds(gatherData(message, thisGuild, thisChannel)).queue();
     }
 
     @Override
@@ -50,6 +78,12 @@ public class QuoteCommand extends Command {
             return;
         }
 
+        boolean thisGuild = event.getMessage().isFromGuild() && event.getGuild().getId().equals(message.getGuild().getId());
+        boolean thisChannel = event.getChannel().getId().equals(message.getChannel().getId());
+        event.reply(gatherData(message, thisGuild, thisChannel));
+    }
+
+    private MessageEmbed gatherData(Message message, boolean thisGuild, boolean thisChannel) {
         // Get message details and send
         EmbedBuilder embed = new EmbedBuilder();
         embed.setTitle("Quote");
@@ -57,8 +91,6 @@ public class QuoteCommand extends Command {
         embed.setTimestamp(message.getTimeCreated());
         embed.setAuthor(message.getAuthor().getAsTag(), null, message.getAuthor().getAvatarUrl());
         if (message.isFromGuild()) {
-            boolean thisGuild = event.getMessage().isFromGuild() && event.getGuild().getId().equals(message.getGuild().getId());
-            boolean thisChannel = event.getChannel().getId().equals(message.getChannel().getId());
             if (!thisGuild) {
                 embed.addField("Server", message.getGuild().getName(), true);
             }
@@ -77,7 +109,7 @@ public class QuoteCommand extends Command {
             embed.addField("Channel", "DMs with " + message.getPrivateChannel().getUser().getAsTag(), true);
         }
 
-        event.reply(embed.build());
+        return embed.build();
     }
 
     private Message retrieveMessage(CommandEvent event) {
@@ -95,20 +127,8 @@ public class QuoteCommand extends Command {
             // Check if it's a link
             String[] link = arg.split("/");
             if (link.length == 7) {
-                String serverId = link[4];
-                String channelId = link[5];
-                String messageId = link[6];
-                if (serverId.equals("@me")) {
-                    channel = event.getJDA().getPrivateChannelById(channelId);
-                } else {
-                    channel = event.getJDA().getTextChannelById(channelId);
-                }
-
-                if (channel == null)
-                    throw new IllegalArgumentException("Channel was invalid!");
-
                 try {
-                    return channel.retrieveMessageById(messageId).complete();
+                    return retrieveMessageFromLink(link, event.getJDA());
                 } catch (NullPointerException | IllegalArgumentException e) {
                     throw new IllegalArgumentException("Message ID doesn't exist or is invalid!");
                 }
@@ -131,5 +151,30 @@ public class QuoteCommand extends Command {
         }
 
         throw new IllegalArgumentException("Too many arguments provided!");
+    }
+
+    private Message retrieveMessageFromLink(String[] link, JDA jda) {
+        if (link.length != 7) {
+            throw new IllegalArgumentException("Invalid link provided!");
+        }
+
+        MessageChannel channel;
+        String serverId = link[4];
+        String channelId = link[5];
+        String messageId = link[6];
+        if (serverId.equals("@me")) {
+            channel = jda.getPrivateChannelById(channelId);
+        } else {
+            channel = jda.getTextChannelById(channelId);
+        }
+
+        if (channel == null)
+            throw new IllegalArgumentException("Channel was invalid!");
+
+        try {
+            return channel.retrieveMessageById(messageId).complete();
+        } catch (NullPointerException | IllegalArgumentException e) {
+            throw new IllegalArgumentException("Message ID doesn't exist or is invalid!");
+        }
     }
 }

--- a/src/main/java/pw/chew/chewbotcca/commands/util/QuoteCommand.java
+++ b/src/main/java/pw/chew/chewbotcca/commands/util/QuoteCommand.java
@@ -153,7 +153,7 @@ public class QuoteCommand extends SlashCommand {
         throw new IllegalArgumentException("Too many arguments provided!");
     }
 
-    private Message retrieveMessageFromLink(String[] link, JDA jda) {
+    public static Message retrieveMessageFromLink(String[] link, JDA jda) {
         if (link.length != 7) {
             throw new IllegalArgumentException("Invalid link provided!");
         }

--- a/src/main/java/pw/chew/chewbotcca/listeners/ReadyListener.java
+++ b/src/main/java/pw/chew/chewbotcca/listeners/ReadyListener.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2021 Chewbotcca
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package pw.chew.chewbotcca.listeners;
+
+import com.jagrosh.jdautilities.command.SlashCommand;
+import net.dv8tion.jda.api.events.ReadyEvent;
+import net.dv8tion.jda.api.hooks.ListenerAdapter;
+import net.dv8tion.jda.api.interactions.commands.build.CommandData;
+import org.jetbrains.annotations.NotNull;
+import org.slf4j.LoggerFactory;
+import pw.chew.chewbotcca.Main;
+
+import java.lang.reflect.InvocationTargetException;
+import java.util.ArrayList;
+import java.util.List;
+
+public class ReadyListener extends ListenerAdapter {
+    @Override
+    public void onReady(@NotNull ReadyEvent event) {
+        // Get all commands
+        List<CommandData> data = new ArrayList<>();
+
+        try {
+            for (SlashCommand command : Main.getSlashCommands()) {
+                data.add(command.buildCommandData());
+            }
+        } catch (IllegalAccessException | InstantiationException | NoSuchMethodException | InvocationTargetException e) {
+            e.printStackTrace();
+        }
+
+        event.getJDA().getGuildById("148195924567392257").updateCommands().addCommands(data).queue(commands -> {
+            LoggerFactory.getLogger(this.getClass()).debug("Updated slash commands!");
+        });
+    }
+}

--- a/src/main/java/pw/chew/chewbotcca/objects/IKnowWhatIAmDoingISwearException.java
+++ b/src/main/java/pw/chew/chewbotcca/objects/IKnowWhatIAmDoingISwearException.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright (C) 2021 Chewbotcca
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package pw.chew.chewbotcca.objects;
+
+public class IKnowWhatIAmDoingISwearException extends RuntimeException {
+}

--- a/src/main/java/pw/chew/chewbotcca/objects/Memory.java
+++ b/src/main/java/pw/chew/chewbotcca/objects/Memory.java
@@ -16,6 +16,7 @@
  */
 package pw.chew.chewbotcca.objects;
 
+import com.jagrosh.jdautilities.command.CommandClient;
 import com.jagrosh.jdautilities.commons.waiter.EventWaiter;
 import net.dv8tion.jda.api.JDA;
 import org.kohsuke.github.GitHub;
@@ -29,12 +30,14 @@ public class Memory {
     private static JDA jda;
     private static ChewAPI chewAPI;
     private static GitHub github;
+    private static CommandClient client;
 
-    public Memory(EventWaiter waiter, JDA jda, ChewAPI chewAPI, GitHub github) {
+    public static void remember(EventWaiter waiter, JDA jda, ChewAPI chewAPI, GitHub github, CommandClient client) {
         Memory.waiter = waiter;
         Memory.jda = jda;
         Memory.chewAPI = chewAPI;
         Memory.github = github;
+        Memory.client = client;
     }
 
     /**
@@ -63,5 +66,12 @@ public class Memory {
      */
     public static EventWaiter getWaiter() {
         return waiter;
+    }
+
+    /**
+     * @return the command client used by JDA Utilities
+     */
+    public static CommandClient getClient() {
+        return client;
     }
 }

--- a/src/main/java/pw/chew/chewbotcca/util/PropertiesManager.java
+++ b/src/main/java/pw/chew/chewbotcca/util/PropertiesManager.java
@@ -16,6 +16,9 @@
  */
 package pw.chew.chewbotcca.util;
 
+import net.dv8tion.jda.api.utils.MiscUtil;
+import org.jetbrains.annotations.Nullable;
+
 import java.util.Properties;
 
 // bot.properties manager
@@ -149,5 +152,24 @@ public class PropertiesManager {
      */
     public static String getDatabasePassword() {
         return properties.getProperty("database_pass");
+    }
+
+    /**
+     * This determines whether we should only upsert in a single server, or globally.
+     * In development, this is usually per-server.
+     * In production, this should be null
+     *
+     * @return the forced guild id
+     */
+    @Nullable
+    public static String forceGuildId() {
+        String guildId = properties.getProperty("forced_guild_id");
+        if (guildId.length() < 15) return null;
+        try {
+            MiscUtil.parseSnowflake(guildId);
+        } catch (NumberFormatException e) {
+            return null;
+        }
+        return guildId;
     }
 }

--- a/src/main/java/pw/chew/chewbotcca/util/ResponseHelper.java
+++ b/src/main/java/pw/chew/chewbotcca/util/ResponseHelper.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2021 Chewbotcca
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package pw.chew.chewbotcca.util;
+
+import net.dv8tion.jda.api.EmbedBuilder;
+import net.dv8tion.jda.api.entities.MessageEmbed;
+
+import java.awt.Color;
+
+public class ResponseHelper {
+    /**
+     * Generates a "Failure" embed.
+     *
+     * @param title       a title to override
+     * @param description a description to override
+     * @return the failure embed
+     */
+    public static MessageEmbed generateFailureEmbed(String title, String description) {
+        EmbedBuilder embed = new EmbedBuilder()
+            .setTitle("Uh oh, something went wrong!")
+            .setDescription("Please try the command again")
+            .setColor(Color.RED);
+
+        if (title != null)
+            embed.setTitle(title);
+
+        if (description != null)
+            embed.setDescription(description);
+
+        return embed.build();
+    }
+}

--- a/src/main/java/pw/chew/chewbotcca/util/ResponseHelper.java
+++ b/src/main/java/pw/chew/chewbotcca/util/ResponseHelper.java
@@ -18,9 +18,14 @@ package pw.chew.chewbotcca.util;
 
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.entities.MessageEmbed;
+import net.dv8tion.jda.api.events.interaction.SlashCommandEvent;
+import net.dv8tion.jda.api.interactions.commands.OptionMapping;
 
 import java.awt.Color;
 
+/**
+ * This class provides some methods to help with responding to commands.
+ */
 public class ResponseHelper {
     /**
      * Generates a "Failure" embed.
@@ -42,5 +47,39 @@ public class ResponseHelper {
             embed.setDescription(description);
 
         return embed.build();
+    }
+
+    /**
+     * Guarantees a String option value. Removes the "can be null" check because we know it isn't.
+     *
+     * @param event the slash command event to get options from
+     * @param option the option we want
+     * @param fallback if the option doesn't exist, what should we use instead?
+     * @return the never-null option
+     */
+    public static String guaranteeStringOption(SlashCommandEvent event, String option, String fallback) {
+        for (OptionMapping optionMapping : event.getOptions()) {
+            if (optionMapping.getName().equals(option)) {
+                return optionMapping.getAsString();
+            }
+        }
+        return fallback;
+    }
+
+    /**
+     * Guarantees a boolean option value. Removes the "can be null" check because we know it isn't.
+     *
+     * @param event the slash command event to get options from
+     * @param option the option we want
+     * @param fallback if the option doesn't exist, what should we use instead?
+     * @return the never-null option
+     */
+    public static boolean guaranteeBooleanOption(SlashCommandEvent event, String option, boolean fallback) {
+        for (OptionMapping optionMapping : event.getOptions()) {
+            if (optionMapping.getName().equals(option)) {
+                return optionMapping.getAsBoolean();
+            }
+        }
+        return fallback;
     }
 }


### PR DESCRIPTION
# Command Status

## To be converted
- [x] feedback
- [x] help
- [x] invite
- [x] ping
- [x] privacy
- [x] stats
- [x] acronym
- [x] apod
- [x] cat
- [x] catfact
- [x] coinflip
- [x] dog
- [x] eightball
- [x] numberfact
- [x] qrcode
- [x] roll
- [x] rory
- [x] spigotdrama
- [x] trbmb
- [x] botinfo
- [x] channelinfo
- [x] discrim
- [x] info
- [x] lastfm
- [x] roleinfo
- [x] rubygems
- [x] serverinfo
- [x] userinfo
- [x] userstats
- [x] mcissue
- [x] mcserver
- [x] mcstatus
- [x] mcuser
- [x] mcwiki
- [x] unsuppress
- [x] ghissue
- [x] ghrepo
- [x] ghuser
- [x] ocr
- [x] youtube
- [x] memerator
- [x] reddit
- [x] profile
- [x] serversettings
- [x] define
- [x] paste
- [x] quote
- [x] urbandictionary

## Won't be converted
- `prefix` - Not necessary
- `newissue` - Owner commands won't be converted
- `shutdown` - Owner commands won't be converted
- `syncservers` - Owner commands won't be converted
- `hangar` - Command broken, needs to be fixed (Out of scope)
- `tosdr` - Command broken, needs to be fixed (Out of scope)
- `ban` - Holding off on mod commands until permissions are implemented properly
- `dehoist` - Holding off on mod commands until permissions are implemented properly
- `role` - Holding off on mod commands until permissions are implemented properly
- `permcheck` - Most aren't necessary for slash commands